### PR TITLE
Previous on connection failed

### DIFF
--- a/src/AudioTools/AudioPlayer.h
+++ b/src/AudioTools/AudioPlayer.h
@@ -523,6 +523,7 @@ namespace audio_tools {
 		/// moves to next file
 		virtual bool next(int offset=1) {
 			LOGD(LOG_METHOD);
+			previous_stream = false;
 			active = setStream(p_source->nextStream(offset));
             return active;
 		}
@@ -530,6 +531,7 @@ namespace audio_tools {
 		/// moves to selected file
 		virtual bool setIndex(int idx) {
 			LOGD(LOG_METHOD);
+			previous_stream = false;
             active = setStream(p_source->selectStream(idx));
             return active;
 		}
@@ -537,6 +539,7 @@ namespace audio_tools {
 		/// moves to previous file
 		virtual bool previous(int offset=1) {
 			LOGD(LOG_METHOD);
+			previous_stream = true;
 			active = setStream(p_source->previousStream(offset));
 			return active;
 		}
@@ -590,11 +593,21 @@ namespace audio_tools {
 
 				// move to next stream after timeout
 				if (p_input_stream == nullptr || millis() > timeout) {
-					LOGW("-> timeout - moving to next stream");
-					// open next stream
-					if (!next(1)) {
-						LOGD("stream is null");
+					if (previous_stream == false) {
+						LOGW("-> timeout - moving to next stream");
+						// open next stream
+						if (!next(1)) {
+							LOGD("stream is null");
+						}
 					}
+					else {
+						LOGW("-> timeout - moving to previous stream");
+						// open previous stream
+						if (!previous(1)) {
+							LOGD("stream is null");
+						}
+					}
+
 					timeout = millis() + p_source->timeoutMs();
 				}
 			}
@@ -625,6 +638,7 @@ namespace audio_tools {
 		StreamCopy copier; // copies sound into i2s
 		bool meta_active = false;
 		uint32_t timeout = 0;
+		bool previous_stream = false;
 		float current_volume = -1; // illegal value which will trigger an update
 
 		/// Callback implementation which writes to metadata


### PR DESCRIPTION
There is still one issue, when the program start .begin() and the programe doesn't know if previous or next one is selected and if we have a connection failed as first url it will go to the next on. after that we do previous and than it is going back to the first link.

This is a bad link where I am talking about...
http://mp3.streampower.be/sporza-high

I am thinking of begin with link -1, and than select an index. and than select next,select or previous

are you agree with that or are you thinking on an other solution?