### PR TITLE
Revert "Correction"

### DIFF
--- a/src/AudioTools/AudioPlayer.h
+++ b/src/AudioTools/AudioPlayer.h
@@ -596,7 +596,7 @@ namespace audio_tools {
             p_source->begin();
             meta_out.begin();
             
-            if (index >= 0) {
+            if (index > 0) {
                 p_input_stream = p_source->selectStream(index);
                 if (p_input_stream != nullptr) {
                     if (meta_active) {


### PR DESCRIPTION
Reverts pschatzmann/arduino-audio-tools#53

Was already in player.begin (isactive)