### PR TITLE
Revert "Activated turning false"

### DIFF
--- a/src/AudioTools/AudioPlayer.h
+++ b/src/AudioTools/AudioPlayer.h
@@ -731,10 +731,6 @@ namespace audio_tools {
                     // reset timeout
                     timeout = millis() + p_source->timeoutAutoNext();
                 }
-                else
-                {
-                    active = false;
-                }
                 // move to next stream after timeout
                 if (p_input_stream == nullptr || millis() > timeout) {
                     if (autonext) {


### PR DESCRIPTION
Reverts pschatzmann/arduino-audio-tools#53

Was already in player.begin (isactive)