### PR TITLE
Fixed incorrect sample count in ConverterNChannels

### DIFF
--- a/src/AudioTools/Filter.h
+++ b/src/AudioTools/Filter.h
@@ -419,7 +419,7 @@ class ConverterNChannels : public BaseConverter<T> {
 
   // convert all samples for each channel separately
   size_t convert(uint8_t *src, size_t size) {
-    int count = size / channels;
+    int count = size / channels / sizeof(T);
     T *sample = (T *)src;
     for (size_t j = 0; j < count; j++) {
       for (int channel = 0; channel < channels; channel++) {


### PR DESCRIPTION
I think I might have found the problem to Issue 17. In Filter.h class ConverterNChannels this code

```
size_t convert(uint8_t *src, size_t size) {
    int count = size / channels;
    T *sample = (T *)src;
```
is not correctly deriving the sample count to process (as size is in bytes) and should read

```
size_t convert(uint8_t *src, size_t size) {
    int count = size / channels / sizeof(T);
    T *sample = (T *)src; 
```
I did try this locally and it removed the artifacts I was seeing