### PR TITLE
added readBytes function to UDPStream

### DIFF
--- a/src/AudioEffects/AudioEffect.h
+++ b/src/AudioEffects/AudioEffect.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <stdint.h> 
+#include <stdint.h>
 #include "AudioTools/AudioLogger.h"
 #include "AudioEffects/AudioParameters.h"
 
@@ -18,7 +18,7 @@ class AudioEffect  {
     public:
         AudioEffect() = default;
         virtual ~AudioEffect() = default;
-        
+
         /// calculates the effect output from the input
         virtual effect_t process(effect_t in) = 0;
 
@@ -68,12 +68,12 @@ class AudioEffect  {
  * @brief Boost AudioEffect
  * @author Phil Schatzmann
  * @copyright GPLv3
- * 
+ *
  */
 
 class Boost : public AudioEffect {
     public:
-        /// Boost Constructor: volume 0.1 - 1.0: decrease result; volume >0: increase result 
+        /// Boost Constructor: volume 0.1 - 1.0: decrease result; volume >0: increase result
         Boost(float volume=1.0){
             effect_value = volume;
         }
@@ -91,7 +91,7 @@ class Boost : public AudioEffect {
         effect_t process(effect_t input){
             if (!active()) return input;
             int32_t result = effect_value * input;
-            // clip to int16_t            
+            // clip to int16_t
             return clip(result);
         }
 
@@ -105,7 +105,7 @@ class Boost : public AudioEffect {
 
 /**
  * @brief Distortion AudioEffect
- * 
+ *
  * @author Phil Schatzmann
  * @copyright GPLv3
  */
@@ -115,7 +115,7 @@ class Distortion : public AudioEffect  {
         /// Distortion Constructor: e.g. use clipThreashold 4990 and maxInput=6500
         Distortion(int16_t clipThreashold=4990, int16_t maxInput=6500){
             p_clip_threashold = clipThreashold;
-            max_input = maxInput;   
+            max_input = maxInput;
         }
 
         Distortion(const Distortion &copy) = default;
@@ -134,12 +134,12 @@ class Distortion : public AudioEffect  {
 
         int16_t maxInput(){
             return max_input;
-        } 
+        }
 
         effect_t process(effect_t input){
             if (!active()) return input;
             //the input signal is 16bits (values from -32768 to +32768
-            //the value of input is clipped to the distortion_threshold value      
+            //the value of input is clipped to the distortion_threshold value
             return clip(input,p_clip_threashold, max_input);
         }
 
@@ -155,7 +155,7 @@ class Distortion : public AudioEffect  {
 
 /**
  * @brief Fuzz AudioEffect
- * 
+ *
  * @author Phil Schatzmann
  * @copyright GPLv3
  */
@@ -247,7 +247,7 @@ class Tremolo : public AudioEffect  {
             float signal_depth = (100.0 - p_percent) / 100.0;
 
             float tremolo_factor = tremolo_depth / rate_count_half;
-            int32_t out = (signal_depth * input) + (tremolo_factor * count * input); 
+            int32_t out = (signal_depth * input) + (tremolo_factor * count * input);
 
             //saw tooth shaped counter
             count+=inc;
@@ -282,10 +282,12 @@ class Tremolo : public AudioEffect  {
 class Delay : public AudioEffect  {
     public:
         /// e.g. depthPercent=50, ms=1000, sampleRate=44100
-        Delay(uint16_t duration_ms=1000, uint8_t depthPercent=50,  uint32_t sampleRate=44100) {
+        Delay(uint16_t duration_ms=1000, float depthPercent=0.5, float feedback=0.3,  uint32_t sampleRate=44100) {
             this->sampleRate = sampleRate;
             p_percent = depthPercent;
+            p_feedback = feedback;
             p_ms = duration_ms;
+
         }
 
         Delay(const Delay &copy) = default;
@@ -298,12 +300,20 @@ class Delay : public AudioEffect  {
             return p_ms;
         }
 
-        void setDepth(uint8_t percent){
+        void setDepth(float percent){
             p_percent = percent;
         }
 
-        uint8_t depth() {
+        float depth() {
             return p_percent;
+        }
+
+        void setFeedback(float feedback){
+            p_feedback = feedback;
+        }
+
+        float feedback() {
+            return p_feedback;
         }
 
         effect_t process(effect_t input) {
@@ -313,9 +323,11 @@ class Delay : public AudioEffect  {
             // get value from buffer
             int32_t value = (p_history->available()<sampleCount) ? input : p_history->read();
             // add actual input value
-            p_history->write(input);
+            int32_t delayValue = (value*p_feedback);
+            // add actual input value
+            p_history->write(delayValue);
             // mix input with result
-            return (value * p_percent / 100) + (input * (100-p_percent)/100); 
+            return (delayValue * p_percent) + (input * (1.0-p_percent));
         }
 
         Delay *clone() {
@@ -324,7 +336,8 @@ class Delay : public AudioEffect  {
 
     protected:
         RingBuffer<effect_t>* p_history=nullptr;
-        uint8_t  p_percent;
+        float p_percent;
+        float p_feedback;
         uint16_t p_ms;
         uint16_t sampleCount=0;
         uint32_t sampleRate;
@@ -391,7 +404,7 @@ class ADSRGain : public AudioEffect {
         float sustainLevel(){
             return adsr->sustainLevel();
         }
-        
+
         void setReleaseRate(float r){
             adsr->setReleaseRate(r);
         }

--- a/src/AudioLibs/Communication.h
+++ b/src/AudioLibs/Communication.h
@@ -348,7 +348,7 @@ class ESPNowStream : public AudioStreamX {
   }
 
   static void default_recv_cb(const uint8_t *mac_addr, const uint8_t *data,
-                              int data_len) {                                
+                              int data_len) {
     LOGD("rec_cb: %d", data_len);
     // make sure that the receive buffer is available - moved from begin to make sure that it is only allocated when needed
     ESPNowStreamSelf->setupReceiveBuffer();
@@ -449,6 +449,18 @@ class UDPStream : public WiFiUDP {
     return remote_address_ext;
   }
 
+  // Reads bytes using WiFi::readBytes
+  size_t readBytes(uint8_t *buffer, size_t length) override {
+    LOGD(LOG_METHOD);
+    size_t len = available();
+    size_t bytes_read = 0;
+    if (len>0){
+        // get the data now
+        bytes_read = WiFiUDP::readBytes((uint8_t*)buffer, length);
+      }
+    return bytes_read;
+  }
+
   /**
    *  Replys will be sent to the initial remote caller
    */
@@ -474,8 +486,8 @@ class UDPStream : public WiFiUDP {
           delay(500);
       }
     }
-  
-    // Performance Hack              
+
+    // Performance Hack
     //client.setNoDelay(true);
     esp_wifi_set_ps(WIFI_PS_NONE);
 


### PR DESCRIPTION
Added `readBytes` to UDPStream. Fixes issues with when using UDPStream with AudioEffects and GeneratorFromStream.

Fixes https://github.com/pschatzmann/arduino-audio-tools/issues/339