### PR TITLE
Include AudioTools.h in AudioLibs/AudioKit.h

### DIFF
--- a/src/AudioLibs/AudioKit.h
+++ b/src/AudioLibs/AudioKit.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "AudioTools.h"
 #include "AudioKitHAL.h"
 #include "AudioI2S/I2SConfig.h"
 #include "AudioTools/AudioActions.h"


### PR DESCRIPTION
AudioKit.h depends on some definitions in AudioTools.h but it didn't (previously) explicitly include it. This was fine for me until clang-format reordered my includes and then I got *very* confusing errors.

This adds the #include "AudioTools.h" explicitly.