### PR TITLE
AudioFFTResult typo: `frequncyAsInt()` -> `frequencyAsInt()`

### DIFF
--- a/src/AudioLibs/AudioFFT.h
+++ b/src/AudioLibs/AudioFFT.h
@@ -24,7 +24,7 @@ struct AudioFFTResult {
     float magnitude;
     float frequency;
 
-    int frequncyAsInt(){
+    int frequencyAsInt(){
         return round(frequency);
     }
     const char* frequencyAsNote() {


### PR DESCRIPTION
fix #523 