### PR TITLE
Bugfix go to previousStream: avoid negative index position

### DIFF
--- a/src/AudioLibs/AudioA2DP.h
+++ b/src/AudioLibs/AudioA2DP.h
@@ -143,6 +143,10 @@ class A2DPStream : public AudioStream {
                     source(); // allocate object
                     a2dp_source->set_auto_reconnect(cfg.auto_reconnect);
                     a2dp_source->set_volume(volume * 100);
+                    if(cfg.name==nullptr){
+                        //search next available device
+                        a2dp_source->set_ssid_callback(detectedDevice);
+                    }
                     a2dp_source->set_on_connection_state_changed(a2dpStateCallback, this);
                     a2dp_source->start((char*)cfg.name, a2dp_stream_source_sound_data);  
                     while(!a2dp_source->is_connected()){
@@ -291,6 +295,12 @@ class A2DPStream : public AudioStream {
         // semaphore to synchronize acess to the buffer
         SemaphoreHandle_t xSemaphore = NULL;
 
+        // auto-detect device to send audio to (TX-Mode)
+        static bool detectedDevice(const char* ssid, esp_bd_addr_t address, int rssi){
+            LOGW("available SSID: %s", ssid);
+            return true;
+        }
+    
         static void a2dpStateCallback(esp_a2d_connection_state_t state, void *caller){
             TRACED();
             A2DPStream *self = (A2DPStream*)caller;

--- a/src/AudioLibs/AudioA2DP.h
+++ b/src/AudioLibs/AudioA2DP.h
@@ -143,10 +143,6 @@ class A2DPStream : public AudioStream {
                     source(); // allocate object
                     a2dp_source->set_auto_reconnect(cfg.auto_reconnect);
                     a2dp_source->set_volume(volume * 100);
-                    if(cfg.name==nullptr){
-                        //search next available device
-                        a2dp_source->set_ssid_callback(detectedDevice);
-                    }
                     a2dp_source->set_on_connection_state_changed(a2dpStateCallback, this);
                     a2dp_source->start((char*)cfg.name, a2dp_stream_source_sound_data);  
                     while(!a2dp_source->is_connected()){
@@ -295,12 +291,6 @@ class A2DPStream : public AudioStream {
         // semaphore to synchronize acess to the buffer
         SemaphoreHandle_t xSemaphore = NULL;
 
-        // auto-detect device to send audio to (TX-Mode)
-        static bool detectedDevice(const char* ssid, esp_bd_addr_t address, int rssi){
-            LOGW("available SSID: %s", ssid);
-            return true;
-        }
-    
         static void a2dpStateCallback(esp_a2d_connection_state_t state, void *caller){
             TRACED();
             A2DPStream *self = (A2DPStream*)caller;

--- a/src/AudioLibs/AudioSourceSDFAT.h
+++ b/src/AudioLibs/AudioSourceSDFAT.h
@@ -101,9 +101,11 @@ public:
   }
 
   virtual Stream *selectStream(int index) override {
-    LOGI("selectStream: %d", index);
-    idx_pos = index;
-    return selectStream(idx[index]);
+    LOGI("selectStream SDFAT: %d", index);
+    if(index > -1){ //avoid invalid position
+      idx_pos = index;
+    }
+    return selectStream(idx[idx_pos]);
   }
 
   virtual Stream *selectStream(const char *path) override {

--- a/src/AudioLibs/AudioSourceSDFAT.h
+++ b/src/AudioLibs/AudioSourceSDFAT.h
@@ -121,6 +121,7 @@ public:
     }
 
     LOGI("-> selectStream: %s", path);
+    strncpy(file_name, path, MAX_FILE_LEN);
     file = new_file;
     return &file;
   }


### PR DESCRIPTION
Hello Mr. Schatzmann,
thanks a lot for this amazing audio tools!
When creating a small SD player, I keep getting trouble when the title jumps back at the first position.
This error occurs: `AudioSourceSdFat.h - Filename is null`.
After that, the player can no longer be used.
This small change fixed the issue and everything works as it should.