### PR TITLE
Update AnalogAudioESP32.h

### DIFF
--- a/src/AudioAnalog/AnalogAudioESP32.h
+++ b/src/AudioAnalog/AnalogAudioESP32.h
@@ -56,7 +56,7 @@ class AnalogDriverESP32  : public AnalogDriverBase {
             .mode                   = (i2s_mode_t)cfg.mode_internal,
             .sample_rate            = (eps32_i2s_sample_rate_type)cfg.sample_rate,
             .bits_per_sample        = (i2s_bits_per_sample_t)cfg.bits_per_sample,
-            .channel_format         = I2S_CHANNEL_FMT_RIGHT_LEFT,
+            .channel_format         = cfg.channels == 2 ? I2S_CHANNEL_FMT_RIGHT_LEFT : I2S_CHANNEL_FMT_ONLY_LEFT,
             .communication_format   = (i2s_comm_format_t)0,
             .intr_alloc_flags       = 0,
             .dma_buf_count          = cfg.buffer_count,

--- a/src/AudioAnalog/AnalogAudioESP32.h
+++ b/src/AudioAnalog/AnalogAudioESP32.h
@@ -56,7 +56,7 @@ class AnalogDriverESP32  : public AnalogDriverBase {
             .mode                   = (i2s_mode_t)cfg.mode_internal,
             .sample_rate            = (eps32_i2s_sample_rate_type)cfg.sample_rate,
             .bits_per_sample        = (i2s_bits_per_sample_t)cfg.bits_per_sample,
-            .channel_format         = cfg.channels == 2 ? I2S_CHANNEL_FMT_RIGHT_LEFT : I2S_CHANNEL_FMT_ONLY_LEFT,
+            .channel_format         = channel_format = (channels == 1 && rx_tx_mode == RX_MODE) ? I2S_CHANNEL_FMT_ONLY_LEFT :I2S_CHANNEL_FMT_RIGHT_LEFT,
             .communication_format   = (i2s_comm_format_t)0,
             .intr_alloc_flags       = 0,
             .dma_buf_count          = cfg.buffer_count,


### PR DESCRIPTION
When mono is set in the config, the sample frequency appears to be off by a factor 2. 
Reason: channel_format is not set correctly.
Fix:  set according to number of channels