### PR TITLE
Remove unused A2DP include

### DIFF
--- a/examples/examples-basic-api/base-adc-serial/base-adc-serial.ino
+++ b/examples/examples-basic-api/base-adc-serial/base-adc-serial.ino
@@ -9,7 +9,6 @@
  */
  
 #include "Arduino.h"
-#include "BluetoothA2DPSource.h"
 #include "AudioTools.h"
 
 /**


### PR DESCRIPTION
I think this include may have been copied from a different example. I can't see any reason this example needs it and it builds fine without it.

Only noticed this because it makes this example require the A2DP library which I didn't have installed.