### PR TITLE
SD card hot swap

### DIFF
--- a/src/AudioLibs/AudioSourceSDFAT.h
+++ b/src/AudioLibs/AudioSourceSDFAT.h
@@ -92,6 +92,18 @@ public:
     idx_pos = 0;
   }
 
+  void beginEx() {
+    TRACED();
+    if (!sd.begin(*p_cfg)) {
+      LOGE("sd.begin failed");
+      return;
+    }
+    idx.begin(start_path, exension, file_name_pattern);
+    idx_pos = 0;
+  }
+
+  void end() { sd.end(); }  
+
   virtual Stream *nextStream(int offset = 1) override {
     LOGI("nextStream: %d", offset);
     return selectStream(idx_pos + offset);


### PR DESCRIPTION
I add in AudioSourceSDFAT.h
```
void beginEx() {
  TRACED();
  if (!sd.begin(*p_cfg)) {
    LOGE("sd.begin failed");
    return;
  }
  idx.begin(start_path, exension, file_name_pattern);
  idx_pos = 0;
}

void end() { sd.end(); }  
```

Check whether the SD card is inserted in loop(), if it is inserted, execute the following code
```
source.end();
SPI.begin(SPI_CLK, SPI_MISO, SPI_MOSI, SD_CS);
source.beginEx();
```