### PR TITLE
Fix return value of AnalogDriverArduino::readBytes

### DIFF
--- a/src/AudioAnalog/AnalogAudioArduino.h
+++ b/src/AudioAnalog/AnalogAudioArduino.h
@@ -51,7 +51,7 @@ class AnalogDriverArduino : public AnalogDriverBase {
   size_t readBytes(uint8_t *values, size_t len) {
     if (buffer==nullptr) return 0;
     int samples = len / 2;
-    return buffer->readArray((int16_t *)values, samples);
+    return buffer->readArray((int16_t *)values, samples) * 2;
   }
 
  protected:


### PR DESCRIPTION
AnalogDriverArduino::readBytes is supposed to return the number of bytes written to the array passed in as first argument. It does this by calling `buffer->readArray` and returning the same value returned by that function. However, that function actually returns the number of int16_t samples, each of which is 2 bytes, so in fact the readBytes function should return that value multiplied by 2.

This is particularly important because if AnalogDriverArduino::readBytes returns a value of 1, then many of the end consumers will simply drop that value. This is because many of the end consumers divide the number of bytes by 2 again to get the number of samples, and in integer arithmetic, dividing 1 by 2 gives 0. In some circumstances this can lead to a lot of samples being dropped.

This pr just adds the "times 2" to AnalogDriverArduino::readBytes