### PR TITLE
Fixed typo setDeboundDelay() to setDebounceDelay()

### DIFF
--- a/src/AudioTools/AudioActions.h
+++ b/src/AudioTools/AudioActions.h
@@ -135,7 +135,7 @@ class AudioActions {
   }
 
   /// Defines the debounce delay
-  void setDeboundDelay(int value) { debounceDelayValue = value; }
+  void setDebounceDelay(int value) { debounceDelayValue = value; }
   /// Defines the touch limit (Default 20)
   void setTouchLimit(int value) { touchLimit = value; }
 


### PR DESCRIPTION
The method name contained the typo. Discussed in issue previously and fixed now, as per your suggestion.