### PR TITLE
Arduino-pico/I2S::availableForWrite() now returns bytes

### DIFF
--- a/src/AudioI2S/I2SRP2040.h
+++ b/src/AudioI2S/I2SRP2040.h
@@ -143,11 +143,10 @@ class I2SDriverRP2040 {
     }
 
     int availableForWrite()  {
-      //availableForWrite() returns amount of 32-bit words NOT amount of Bytes! *4 to get bytes
       if (cfg.channels == 1){
-        return i2s.availableForWrite()*4/2;// return half of it because we double when writing
+        return i2s.availableForWrite()/2;// return half of it because we double when writing
       } else {
-        return i2s.availableForWrite()*4;
+        return i2s.availableForWrite();
       } 
     }
 


### PR DESCRIPTION
...In the next release of arduino-pico (probably later this week).

https://github.com/earlephilhower/arduino-pico/commit/2888f4d03da70d43912a209971fece3bc6eef56c

P.S: The [cracking and popping](https://github.com/pschatzmann/arduino-audio-tools/issues/857#issuecomment-1573857458) are fixed in that coming release, too.