### PR TITLE
Fixed point math for VolumeStream

### DIFF
--- a/src/AudioConfig.h
+++ b/src/AudioConfig.h
@@ -28,6 +28,8 @@
 
 #define AUDIOTOOLS_VERSION "0.9.4"
 
+//#define PREFER_FIXEDPOINT //uses fixed point multiplication instead float for VolumeStream for slightly better performance on platforms without float hardware. Tested on RP2040 at 16 bit per second (still too slow for 32bit)
+
 /**
  * ------------------------------------------------------------------------- 
  * @brief Logging

--- a/src/AudioTools/VolumeStream.h
+++ b/src/AudioTools/VolumeStream.h
@@ -187,7 +187,15 @@ class VolumeStream : public AudioStream {
               LOGI("setVolume: %f", volume_value);
               float factor = volumeControl().getVolumeFactor(volume_value);
               volume_values[channel]=volume_value;
+              #ifdef PREFER_FIXEDPOINT
+              //convert float to fixed point 2.6
+              //Fixedpoint-Math from https://github.com/earlephilhower/ESP8266Audio/blob/0abcf71012f6128d52a6bcd155ed1404d6cc6dcd/src/AudioOutput.h#L67
+              if(factor > 4.0) factor = 4.0;//factor can only be >1 if allow_boost == true TODO: should we update volume_values[channel] if factor got clipped to 4.0?
+              uint8_t factorF2P6 = (uint8_t) (factor*(1<<6));
+              factor_for_channel[channel] = factorF2P6;
+              #else
               factor_for_channel[channel]=factor;
+              #endif
             } else {
               LOGE("Invalid channel %d - max: %d", channel, info.channels-1);
             }
@@ -211,7 +219,11 @@ class VolumeStream : public AudioStream {
         SimulatedAudioPot pot_vc;
         CachedVolumeControl cached_volume{pot_vc};
         Vector<float> volume_values;
+        #ifdef PREFER_FIXEDPOINT
+        Vector<uint8_t> factor_for_channel; //Fixed point 2.6
+        #else
         Vector<float> factor_for_channel;
+        #endif
         bool is_started = false;
         float max_value = 32767; // max value for clipping
         int max_channels=0;
@@ -256,7 +268,11 @@ class VolumeStream : public AudioStream {
             return cached_volume;
         }
 
+        #ifdef PREFER_FIXEDPOINT
+        uint8_t factorForChannel(int channel){
+        #else
         float factorForChannel(int channel){
+        #endif
             return factor_for_channel.size()==0? 1.0 : factor_for_channel[channel];
         }
 
@@ -266,7 +282,7 @@ class VolumeStream : public AudioStream {
                     applyVolume16((int16_t*)buffer, size/2);
                     break;
                 case 24:
-                    applyVolume24((int24_t*)buffer, size/3);
+                    applyVolume24((int24_t*)buffer, size/3);//TODO is that size/3 right? sizeof(int24_t) is 4
                     break;
                 case 32:
                     applyVolume32((int32_t*)buffer, size/4);
@@ -278,7 +294,11 @@ class VolumeStream : public AudioStream {
 
         void applyVolume16(int16_t* data, size_t size){
             for (size_t j=0;j<size;j++){
+                #ifdef PREFER_FIXEDPOINT
+                int32_t result = (data[j] * factorForChannel(j%info.channels)) >> 6; //Fixedpoint-Math from https://github.com/earlephilhower/ESP8266Audio/blob/0abcf71012f6128d52a6bcd155ed1404d6cc6dcd/src/AudioOutput.h#L67
+                #else
                 float result = factorForChannel(j%info.channels) * data[j];
+                #endif
                 if (!info.allow_boost){
                     if (result>max_value) result = max_value;
                     if (result<-max_value) result = -max_value;
@@ -289,7 +309,11 @@ class VolumeStream : public AudioStream {
 
         void applyVolume24(int24_t* data, size_t size) {
             for (size_t j=0;j<size;j++){
+                #ifdef PREFER_FIXEDPOINT
+                int32_t result = (data[j] * factorForChannel(j%info.channels)) >> 6; //8bits * 24bits = fits into 32
+                #else
                 float result = factorForChannel(j%info.channels) * data[j];
+                #endif
                 if (!info.allow_boost){
                     if (result>max_value) result = max_value;
                     if (result<-max_value) result = -max_value;
@@ -301,7 +325,11 @@ class VolumeStream : public AudioStream {
 
         void applyVolume32(int32_t* data, size_t size) {
             for (size_t j=0;j<size;j++){
+                #ifdef PREFER_FIXEDPOINT
+                int64_t result = (static_cast<int64_t>(data[j]) * static_cast<int64_t>(factorForChannel(j%info.channels))) >> 6;
+                #else
                 float result = factorForChannel(j%info.channels) * data[j];
+                #endif
                 if (!info.allow_boost){
                     if (result>max_value) result = max_value;
                     if (result<-max_value) result = -max_value;


### PR DESCRIPTION
#926 
Math copied from [Earle Philhower's ESP8266Audio (GPLv3)](https://github.com/earlephilhower/ESP8266Audio/blob/0abcf71012f6128d52a6bcd155ed1404d6cc6dcd/src/AudioOutput.h#L67)

The performance difference is actually smaller than I expected. My initial issue was fixed by just increasing the SD-Card's SPI speed. At more than about 30MHz SPI speed, it's fast enough to play a 16 bit per sample, 44100Hz, 1411kBit/s WAV file from the SD-card even with float volume control.
Still, the performance improvement of fixed point could be needed for a program that does more.
I suggest integrating it an optional thing.

Using 2.6 bit fixed point, the steps between available volume values are quite large, and the maximum volume boost is only 4. I think we could instead use 8.8. 
And I'm not sure if we should update `volume_values[channel]` if the factor got clipped to the maximum of the fixed point value (4.0).

- With a 16Bit per sample wav file, I can't hear a difference between float and fixed point. When the SD-card's SPI is too slow, I can hear more underflow when using float than fixed point.
- 24 Bit per sample wav files didn't work at all. (Even without VolumeStream). Just noise. So I couldn't test that. And I think there's [another bug here](https://github.com/pschatzmann/arduino-audio-tools/blob/0e1c3a070b447aa6ad0ed2a6f14c479cfa64f51d/src/AudioTools/VolumeStream.h#L269C59-L269C59). 
- At 32Bit per second, again, I can't really hear a difference. There's a bit more buffer underflow with float. But the RP2040 seems (at default clock speed 133MHz) too slow for either version.

<details><summary>Performance benchmark sketch</summary>
<p>

```ino
#include <Arduino.h>
#include <AudioTools.h>

MeasuringStream out(50, &Serial);
VolumeStream volume(out);
SilenceGenerator<int16_t> silence(0);
GeneratedSoundStream<int16_t> sound(silence);
StreamCopy copier(volume, sound);

void setup() {
  Serial.begin();
  while(!Serial);
  delay(1000);
  Serial.println("Hallo");

  AudioLogger::instance().begin(Serial,AudioLogger::Error);

  volume.begin();
  volume.setVolume(0.3);
}

void loop() {
  if(!copier.copy()){
    stop();
  }
}
```

</p>
</details> 


```
float:     ==> Bytes per second: 756000
fixedpoint ==> Bytes per second: 949000
```

<details><summary>Listening test sketch</summary>
<p>

Hardware: Pico W, Adafruit MAX98357, Adafruit micro-SD breakout, SanDisk Extreme Pro 32GB

```ino
#include <Arduino.h>
#include <SDFS.h>
#include <AudioTools.h>

I2SStream i2s;
VolumeStream volume(i2s);
EncodedAudioStream decoder(&volume, new WAVDecoder());
//EncodedAudioStream decoder(&i2s, new WAVDecoder());
StreamCopy copier;
File audioFile;

void setup() {
  Serial.begin();
  while(!Serial);
  delay(1000);
  Serial.println("Hello");

  SDFSConfig sdconf;
  sdconf.setCSPin(17);
  sdconf.setSPISpeed(40000000);
  //SPI.setCS(17);
  SPI.setRX(16);
  SPI.setTX(19);
  SPI.setSCK(18);
  SDFS.setConfig(sdconf);
  Serial.println(SDFS.begin());
  //FSInfo64 fsinfo;
  //SDFS.info64(fsinfo);
  //Serial.println(fsinfo.totalBytes);
  //Serial.println(fsinfo.usedBytes);
  Serial.println(SDFS.exists("ashlikesnow16_44100.wav"));
  Serial.println("Let's go");

  audioFile = SDFS.open("ashlikesnow16_44100.wav","r");

  AudioLogger::instance().begin(Serial,AudioLogger::Error);

  I2SConfig i2sconfig = i2s.defaultConfig(TX_MODE);
  i2sconfig.buffer_count = 10;
  i2sconfig.buffer_size = 1024;
  i2sconfig.pin_bck = 26;
  i2sconfig.pin_data =28;
  i2sconfig.pin_ws = 27;
  i2s.begin(i2sconfig);

  decoder.begin();
  volume.begin(i2sconfig);
  volume.setVolume(0.5);
  copier.begin(decoder, audioFile);
}

void loop() {
  // put your main code here, to run repeatedly:
  if(!copier.copy()){
    i2s.end();
    stop();
  }
}
```

</p>
</details> 

