### PR TITLE
FormatConverterStream: fix crash at end of file

### DIFF
--- a/src/AudioTools/ResampleStream.h
+++ b/src/AudioTools/ResampleStream.h
@@ -49,9 +49,8 @@ class TransformationReader {
     LOGD("factor %f -> buffer %d bytes", byte_factor, read_size);
     buffer.resize(read_size);
     int read = p_stream->readBytes(buffer.data(), read_size);
-    assert(read == read_size);
     Print *tmp = setupOutput(data, byteCount);
-    p_transform->write(buffer.data(), read_size);
+    p_transform->write(buffer.data(), read);
     restoreOutput(tmp);
     return print_to_array.totalBytesWritten();
   }


### PR DESCRIPTION
Fixes #946 according to your suggestion https://github.com/pschatzmann/arduino-audio-tools/issues/946#issuecomment-1654111367

To be honest, I'm not familiar with the entire code enough to fully say whether this is just a hacky workaround or a perfect fix.
However, with my example, I can confirm it works!

Code to reproduce: See issue
Before: See issue
After:
Plays entire file fine. log ends reasonably. Ctrl+F counting all
`[I] StreamCopy.h : 139 - StreamCopy::copy 1024 -> 1024 -> 1024 bytes - in 1 hops` lines
+one additional line `[I] StreamCopy.h : 139 - StreamCopy::copy 1024 -> 640 -> 640 bytes - in 1 hops` at the end we can calculate that the entire file is really played. `1024 -> 640 -> 640` is because it wants to read 1024 bytes, but the file already ends after 640 bytes. 
Shortened log after this fix: [device-monitor-230730-203658shortened.log](https://github.com/pschatzmann/arduino-audio-tools/files/12209888/device-monitor-230730-203658shortened.log)

