### PR TITLE
Fix memoryleak & more in AudioPlayer

### DIFF
--- a/src/AudioTools/AudioPlayer.h
+++ b/src/AudioTools/AudioPlayer.h
@@ -386,7 +386,7 @@ namespace audio_tools {
             size_t result = 0;
             if (active) {
                 TRACED();
-                if (delay_if_full!=0 && p_final_print!=nullptr && p_final_print->availableForWrite()==0){
+                if (delay_if_full!=0 && ((p_final_print!=nullptr && p_final_print->availableForWrite()==0) || (p_final_stream!=nullptr && p_final_stream->availableForWrite()==0))){
                     // not ready to do anything - so we wait a bit
                     delay(delay_if_full);
                     return 0;

--- a/src/AudioTools/AudioPlayer.h
+++ b/src/AudioTools/AudioPlayer.h
@@ -41,14 +41,14 @@ namespace audio_tools {
 
     public:
 
-        /// Default constructur 
+        /// Default constructor 
         AudioPlayer() {
             TRACED();
         }
 
         /**
          * @brief Construct a new Audio Player object. The processing chain is
-         * AudioSource -> Stream -copy> EncodedAudioStream -> VolumeOutput -> Print
+         * AudioSource -> Stream-copy -> EncodedAudioStream -> VolumeStream -> FadeStream -> Print
          *
          * @param source
          * @param output
@@ -65,7 +65,7 @@ namespace audio_tools {
 
         /**
          * @brief Construct a new Audio Player object. The processing chain is
-         * AudioSource -> Stream -copy> EncodedAudioStream -> VolumeOutput -> Print
+         * AudioSource -> Stream-copy -> EncodedAudioStream -> VolumeStream -> FadeStream -> Print
          *
          * @param source
          * @param output
@@ -82,7 +82,7 @@ namespace audio_tools {
 
         /**
          * @brief Construct a new Audio Player object. The processing chain is
-         * AudioSource -> Stream -copy> EncodedAudioStream -> VolumeOutput -> Print
+         * AudioSource -> Stream-copy -> EncodedAudioStream -> VolumeStream -> FadeStream -> Print
          *
          * @param source
          * @param output
@@ -111,8 +111,10 @@ namespace audio_tools {
             if (p_decoder->isResultPCM()){
                 this->fade.setTarget(output);
                 this->volume_out.setTarget(fade);
+                delete this->p_out_decoding;
                 this->p_out_decoding = new EncodedAudioStream(&volume_out, p_decoder);
             } else {
+                delete this->p_out_decoding;
                 this->p_out_decoding = new EncodedAudioStream(&output, p_decoder);
             }
             this->p_final_print = &output;
@@ -122,8 +124,10 @@ namespace audio_tools {
             if (p_decoder->isResultPCM()){
                 this->fade.setTarget(output);
                 this->volume_out.setTarget(fade);
+                delete this->p_out_decoding;
                 this->p_out_decoding = new EncodedAudioStream(&volume_out, p_decoder);
             } else {
+                delete this->p_out_decoding;
                 this->p_out_decoding = new EncodedAudioStream(&output, p_decoder);
             }
         }
@@ -132,8 +136,10 @@ namespace audio_tools {
             if (p_decoder->isResultPCM()){
                 this->fade.setTarget(output);
                 this->volume_out.setTarget(fade);
+                delete this->p_out_decoding;
                 this->p_out_decoding = new EncodedAudioStream(&volume_out, p_decoder);
             } else {
+                delete this->p_out_decoding;
                 this->p_out_decoding = new EncodedAudioStream(&output, p_decoder);
             }
             this->p_final_stream = &output;

--- a/src/AudioTools/AudioPlayer.h
+++ b/src/AudioTools/AudioPlayer.h
@@ -118,6 +118,7 @@ namespace audio_tools {
                 this->p_out_decoding = new EncodedAudioStream(&output, p_decoder);
             }
             this->p_final_print = &output;
+            this->p_final_stream = nullptr;
         }
 
         void setOutput(Print &output){
@@ -130,6 +131,8 @@ namespace audio_tools {
                 delete this->p_out_decoding;
                 this->p_out_decoding = new EncodedAudioStream(&output, p_decoder);
             }
+            this->p_final_print = nullptr;
+            this->p_final_stream = nullptr;
         }
 
         void setOutput(AudioStream& output){
@@ -142,6 +145,7 @@ namespace audio_tools {
                 delete this->p_out_decoding;
                 this->p_out_decoding = new EncodedAudioStream(&output, p_decoder);
             }
+            this->p_final_print = nullptr;
             this->p_final_stream = &output;
         }
 

--- a/src/AudioTools/AudioPlayer.h
+++ b/src/AudioTools/AudioPlayer.h
@@ -402,11 +402,7 @@ namespace audio_tools {
             } else {
                 // e.g. A2DP should still receive data to keep the connection open
                 if (silence_on_inactive){
-                    if (p_final_print!=nullptr){
-                        p_final_print->writeSilence(1024);
-                    } else if (p_final_stream!=nullptr){
-                        p_final_stream->writeSilence(1024);
-                    }
+                    writeSilence(1024);
                 }
             }
             return result;


### PR DESCRIPTION
1. Memory leak in setOutput()

Plus two things I'm honestly not sure about. But I just made those changes in separate commits and I think you can just not merge them if they were intended behaviour:

2. Both, `p_final_print` and `p_final_stream` could be set at the same time if: `setOutput(AudioOutput)` and then `setOutput(AudioStream)` was called, or the other way around. Or by using a constructor with AudioOutput/AudioStream and then calling setOutput() with the other option.
3. delay_if_full was only implemented when the output was a AudioOutput (p_final_print) and not an AudioStream (p_final_stream).