### PR TITLE
Error handling & boundary check, type fixes, adc-serial update for ESP32V1

### DIFF
--- a/examples/examples-basic-api/base-adc-serial/base-adc-serial.ino
+++ b/examples/examples-basic-api/base-adc-serial/base-adc-serial.ino
@@ -23,12 +23,33 @@ ConverterScaler<int16_t> scaler(1.0, -26427, 32700 );
 
 // Arduino Setup
 void setup(void) {
+  delay(3000); // Give time to boot
   Serial.begin(115200);
+  // Include logging to serial
+  AudioLogger::instance().begin(Serial, AudioLogger::Info); //Warning, Info
+  Serial.println("starting ADC...");
+  auto adcConfig = adc.defaultConfig(RX_MODE);
+  adcConfig.sample_rate = 44100;
+  // do not set bits_per_sample as that is configured based on adc_bit_with
+  adcConfig.adc_bit_width = 12; // this will result in 16 bits_per_sample
+  adc.begin(adcConfig);
 
-  // start i2s input with default configuration
-  Serial.println("starting I2S-ADC...");
-  adc.begin(adc.defaultConfig(RX_MODE));
-
+  // delay(100);
+  // if (adcConfig.rx_tx_mode == RX_MODE){
+  //   Serial.println("Using RX Mode (ADC)");
+  // }
+  // else if (adcConfig.rx_tx_mode == TX_MODE) {
+  //   Serial.println("Using TX Mode (DAC)");
+  // }
+  // Serial.printf("sample_rate is: %u\n", adcConfig.sample_rate);
+  // Serial.printf("bits_per_sample is: %u\n", adcConfig.bits_per_sample);
+  // Serial.printf("adc_attenuation is: %u\n", adcConfig.adc_attenuation);
+  // Serial.printf("adc_bit_width is: %u\n", adcConfig.adc_bit_width);
+  // Serial.printf("adc mode is: %u\n", adcConfig.adc_conversion_mode);
+  // Serial.printf("adc format is: %u\n", adcConfig.adc_output_type);
+  // for(int i=0; i<adcConfig.channels; i++) {
+  //   Serial.printf("channel[%d] is on pin: %u\n", i, adcConfig.adc_channels[i]);
+  // }
 }
 
 // Arduino loop - repeated processing 

--- a/src/AudioAnalog/AnalogConfigESP32V1.h
+++ b/src/AudioAnalog/AnalogConfigESP32V1.h
@@ -11,7 +11,7 @@
 #define ADC_CHANNELS        {ADC_CHANNEL_6, ADC_CHANNEL_7}
 #define HAS_ESP32_DAC
 #elif CONFIG_IDF_TARGET_ESP32S2
-#define ADC_CONV_MODE       ADC_CONV_BOTH_UNIT
+#define ADC_CONV_MODE       ADC_CONV_BOTH_UNIT // might only work with single unit
 #define ADC_OUTPUT_TYPE     ADC_DIGI_OUTPUT_FORMAT_TYPE2
 #define ADC_CHANNELS        {ADC_CHANNEL_2, ADC_CHANNEL_3}
 #define HAS_ESP32_DAC
@@ -20,7 +20,7 @@
 #define ADC_OUTPUT_TYPE     ADC_DIGI_OUTPUT_FORMAT_TYPE2
 #define ADC_CHANNELS        {ADC_CHANNEL_2, ADC_CHANNEL_3}
 #elif CONFIG_IDF_TARGET_ESP32S3
-#define ADC_CONV_MODE       ADC_CONV_BOTH_UNIT
+#define ADC_CONV_MODE       ADC_CONV_BOTH_UNIT // might only work with single unit
 #define ADC_OUTPUT_TYPE     ADC_DIGI_OUTPUT_FORMAT_TYPE2
 #define ADC_CHANNELS        {ADC_CHANNEL_2, ADC_CHANNEL_3}
 #endif
@@ -52,12 +52,16 @@ class AnalogConfigESP32V1 : public AudioInfo {
     bool use_apll = false;
 
     // public config parameters
-    int adc_conversion_mode = ADC_CONV_MODE;
-    int adc_output_type = ADC_OUTPUT_TYPE;
-    int adc_attenuation = ADC_ATTEN_DB_0;
-    int adc_bit_width = SOC_ADC_DIGI_MAX_BITWIDTH;
+    adc_digi_convert_mode_t adc_conversion_mode = ADC_CONV_MODE;
+    adc_digi_output_format_t adc_output_type = ADC_OUTPUT_TYPE;
+    uint8_t adc_attenuation = ADC_ATTEN_DB_0;
+    uint8_t adc_bit_width = SOC_ADC_DIGI_MAX_BITWIDTH;
+    uint32_t sample_rate = SOC_ADC_SAMPLE_FREQ_THRES_LOW;
     /// ESP32: ADC_CHANNEL_6, ADC_CHANNEL_7; others ADC_CHANNEL_2, ADC_CHANNEL_3
     adc_channel_t adc_channels[2] = ADC_CHANNELS;
+    uint32_t channels = 2;    
+    int bits_per_sample = 16;
+
 #ifdef HAS_ESP32_DAC
     /// ESP32: DAC_CHANNEL_MASK_CH0 or DAC_CHANNEL_MASK_CH1
     dac_channel_mask_t dac_mono_channel = DAC_CHANNEL_MASK_CH0;
@@ -65,7 +69,7 @@ class AnalogConfigESP32V1 : public AudioInfo {
     /// Default constructor
     AnalogConfigESP32V1(RxTxMode rxtxMode=TX_MODE) {
       sample_rate = 44100;
-      bits_per_sample = 16;
+      adc_bit_width  = 12;
       channels =  2;
       rx_tx_mode = rxtxMode;
       if (rx_tx_mode == RX_MODE) {

--- a/src/AudioTools/AudioTypes.h
+++ b/src/AudioTools/AudioTypes.h
@@ -46,6 +46,14 @@ INLINE_VAR const char* TimeUnitStr[] {"MS","US","HZ"};
  * @ingroup basic
  */
 struct AudioInfo {
+
+    /// Sample Rate: e.g 44100
+    int sample_rate = DEFAULT_SAMPLE_RATE;    
+    /// Number of channels: 2=stereo, 1=mono
+    int channels = DEFAULT_CHANNELS;  
+    /// Number of bits per sample (int16_t = 16 bits)    
+    int bits_per_sample = DEFAULT_BITS_PER_SAMPLE; 
+
     /// Default constructor
     AudioInfo() = default;
 
@@ -100,13 +108,6 @@ struct AudioInfo {
       //}
     }  
 
-    /// Sample Rate: e.g 44100
-    int sample_rate = DEFAULT_SAMPLE_RATE;    
-    /// Number of channels: 2=stereo, 1=mono
-    int channels = DEFAULT_CHANNELS;  
-    /// Number of bits per sample (int16_t = 16 bits)    
-    int bits_per_sample = DEFAULT_BITS_PER_SAMPLE; 
-    
 };
 
 /**


### PR DESCRIPTION
Merged my changes for in ESP32V1:

- added more log information when setting up continuous ADC, 
- added setting of bits_per_sample based on adc_sample_width, 
- updated base-adc-serial.ino to include custom settings
- moved default settings in AudioTools/AudioTypes.h to beginning of class (not sure if necessary)

Thanks Phil, 
I saw the you already fixed the issues hat did not set sample rate (empty config) and added the start command at the end of setup_rx. I think its necessary to give user the option to set adc_bit_width and then automatically update the bits_per_sample as multiple of 8. Also some of the types in the Configs V1 file were not correct.
I tested the code with base-adc-serial and modified it to provide other than default settings on ESP32 Dev Module. I will test on ESP32S3 later.
Urs