### PR TITLE
Udated ESP32 ADC stream

### DIFF
--- a/examples/examples-basic-api/base-adc-measure/base-adc-measure.ino
+++ b/examples/examples-basic-api/base-adc-measure/base-adc-measure.ino
@@ -1,0 +1,65 @@
+#include "Arduino.h"
+#include "AudioTools.h"
+
+// On board analog to digital converter
+AnalogAudioStream analog_in; 
+
+// Measure throughput
+MeasuringStream measure(1000, &Serial);
+
+// Copy input to output
+StreamCopy copier(measure, analog_in);
+
+void setup() {
+  // Serial Interface
+  Serial.begin(115200);
+  // Include logging to serial
+  AudioLogger::instance().begin(Serial, AudioLogger::Info); //Warning, INfo
+  
+  // Start ADC input
+  Serial.println("Starting ADC...");
+  auto adcConfig = analog_in.defaultConfig(RX_MODE);
+  adcConfig.sample_rate = 2000000;
+  adcConfig.adc_bit_width = 12;
+  analog_in.begin(adcConfig);
+
+  // Start Measurements
+  AudioLogger::instance().begin(Serial, AudioLogger::Warning); //Warning, INfo
+  Serial.println("Starting through put measurement...");
+}
+
+void loop() {
+  copier.copy(); 
+}
+
+/* Adafruit Feather ESP32-S3 2MB PSRAM
+  Data: bytes per second, single unit  
+   SPS  :  expected,  measured (might be per channel)
+    8,000:   64,000,    32,000
+   11,025:   88,200,    44,000
+   16,000:  128,000,    64,000
+   20,000:  160,000,    80,000
+   22,050:  176,400,    88,000
+   44,100:  352,800,   179,000
+   48,000:  384,000,   192,000
+   88,200:    error, sample rate: 88200 error, range: 611 to 83333
+*/
+
+/* DOIT ESP32 DEVKIT V1
+  Data: bytes per second, single unit
+   SPS  :  expected,  measured (might be per channel) 80% of expected
+   16000:  error, sample rate: 16000 warning, range: 20000 to 2000000
+   20000:    80,000,    32,000
+   22050:    88,200,    36,000
+   44100:   176,400,    72,000
+   48000:   192,000,    77,000
+   88200:   352,800,   144,000
+   96000:   384,000,   157,000
+  176400:   704,000,   288,000 
+  192200:   768,800,   314,000
+  352800: 1,411,200,   576,000
+  384000: 1,536,000,   627,000
+ 1000000: 4,000,000, 1,640,000
+ 1500000: 6,000,000, 2,455,000
+ 2000000: 8,000,000, 3,271,000
+*/

--- a/src/AudioAnalog/AnalogAudioESP32V1.h
+++ b/src/AudioAnalog/AnalogAudioESP32V1.h
@@ -63,14 +63,19 @@ public:
   /// stops the I2S and uninstalls the driver
   void end() override {
     TRACEI();
-#ifdef HAS_ESP32_DAC
+  #ifdef HAS_ESP32_DAC
     if (active_tx) {
       dac_continuous_del_channels(dac_handle);
     }
-#endif
+  #endif
     if (active_rx) {
       adc_continuous_stop(adc_handle);
-      adc_continuous_deinit(adc_handle);
+      adc_continuous_deinit(adc_handle);    
+  #if ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED        
+      adc_cali_delete_scheme_curve_fitting(adc_cali_handle);
+  #elif !defined(CONFIG_IDF_TARGET_ESP32H2)
+      adc_cali_delete_scheme_line_fitting(adc_cali_handle);
+  #endif
     }
     converter.end();
     active_tx = false;
@@ -78,27 +83,66 @@ public:
     active = false;
   }
 
-  /// writes the data to the DAC
+  // writes the data to the DAC
   size_t write(const uint8_t *src, size_t size_bytes) override {
     TRACED();
     return io.write(src, size_bytes);
   }
 
+  // reads data from DMA buffer
   size_t readBytes(uint8_t *dest, size_t size_bytes) override {
     TRACED();
-    uint32_t result = 0;
-    size_t samples = size_bytes / 2;
 
-    if (adc_continuous_read(adc_handle, dest, samples, &result, timeout) ==
-        ESP_OK) {
-      // convert unsigned to signed ?
-    } else {
-      result = 0;
+    int data_milliVolts;    
+    uint32_t bytes_read = 0;
+
+    // size_bytes should be multiple of SOC_ADC_DIGI_RESULT_BYTES
+    if ( (size_bytes % SOC_ADC_DIGI_RESULT_BYTES) !=0) {
+      LOGE("requested %d bytes is not a multiple of %d", size_bytes, SOC_ADC_DIGI_RESULT_BYTES);
+      return 0;
     }
-    return result * 2;
+
+    size_t num_samples = size_bytes / SOC_ADC_DIGI_RESULT_BYTES;
+    LOGI("requesting %d bytes, %d samples", size_bytes, num_samples);
+
+    // Manual says
+    // read DMA buffer (hanndle, bufffer, expected length in bytes, real length in bytes, timeout in ms)
+    esp_err_t err = adc_continuous_read(adc_handle, dest, size_bytes, &bytes_read, timeout);
+    if (err != ESP_OK) {
+      if ( err == ESP_ERR_TIMEOUT) { LOGE("reading data failed, increase timeout"); } 
+      else { LOGE("reading data failed with error %d", err); }
+      dest = NULL;
+      return 0;
+    }
+    
+    LOGI("received %d bytes, %d samples, at %d ms", bytes_read, bytes_read / SOC_ADC_DIGI_RESULT_BYTES, millis());
+
+    // Calibrate the ADC readings
+    for (int i = 0; i < bytes_read; i += SOC_ADC_DIGI_RESULT_BYTES) {
+      int raw_data;
+    #if SOC_ADC_DIGI_RESULT_BYTES == 4
+      raw_data = *(uint32_t *) &dest[i];
+    #else
+      raw_data = *(uint16_t *) &dest[i];
+    #endif
+        err = adc_cali_raw_to_voltage(adc_cali_handle, raw_data, &data_milliVolts);
+        if (err == ESP_OK) {
+    #if SOC_ADC_DIGI_RESULT_BYTES == 4
+        *(uint32_t *) &dest[i] = (uint32_t) data_milliVolts;
+    #else
+        *(uint16_t *) &dest[i] = (uint16_t) data_milliVolts;
+    #endif
+        } else { LOGE("converting data to milliVolts failed with error: %d", err); }
+    }
+    LOGI("calibrated %d bytes %d samples", bytes_read, bytes_read / SOC_ADC_DIGI_RESULT_BYTES);
+
+    return bytes_read; 
   }
+
+  // is data in the ADC buffer?
   int available() override { return active_rx ? DEFAULT_BUFFER_SIZE : 0; }
 
+  // set ADC read timtout
   void setTimeout(int value) { timeout = value; }
 
 protected:
@@ -106,6 +150,7 @@ protected:
   dac_continuous_handle_t dac_handle;
 #endif
   adc_continuous_handle_t adc_handle;
+  adc_cali_handle_t adc_cali_handle; 
   AnalogConfigESP32V1 cfg;
   bool active = false;
   bool active_tx = false;
@@ -147,7 +192,6 @@ protected:
   NumberFormatConverterStream converter{io};
 
 #ifdef HAS_ESP32_DAC
-
   bool setup_tx() {
     dac_continuous_config_t cont_cfg = {
         .chan_mask =
@@ -190,12 +234,49 @@ protected:
     } else {
       LOGI("channels: %d, max: %d", cfg.channels, max_channels);
     }
-    adc_continuous_handle_cfg_t adc_config = {
-        .max_store_buf_size = (uint32_t)cfg.buffer_size * cfg.buffer_count,
-        .conv_frame_size = (uint32_t)cfg.buffer_size /
-                           SOC_ADC_DIGI_DATA_BYTES_PER_CONV *
-                           SOC_ADC_DIGI_DATA_BYTES_PER_CONV,
-    };
+
+    adc_continuous_handle_cfg_t adc_config;
+
+    // Code from esp32-hal-adc.c:
+    // adc_handle[adc_unit].conversion_frame_size = conversions_per_pin * pins_count * SOC_ADC_DIGI_RESULT_BYTES;
+    // #if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
+    //     uint8_t calc_multiple = adc_handle[adc_unit].conversion_frame_size % SOC_ADC_DIGI_DATA_BYTES_PER_CONV;
+    //     if(calc_multiple != 0){
+    //         adc_handle[adc_unit].conversion_frame_size = (adc_handle[adc_unit].conversion_frame_size + calc_multiple);
+    //     }
+    // #endif
+    // adc_handle[adc_unit].buffer_size = adc_handle[adc_unit].conversion_frame_size * 2;
+    // adc_continuous_handle_cfg_t adc_config = {
+    //     .max_store_buf_size = adc_handle[adc_unit].buffer_size,
+    //     .conv_frame_size = adc_handle[adc_unit].conversion_frame_size,
+    // };
+
+    /* Because ESPs have different ADC DMA and conversion configurations
+       we need to adjust the frame_size accordingly
+        ESP32S2
+          SOC_ADC_DIGI_RESULT_BYTES        (2)
+          SOC_ADC_DIGI_DATA_BYTES_PER_CONV (2)
+        ESP32 
+          SOC_ADC_DIGI_RESULT_BYTES        (2)
+          SOC_ADC_DIGI_DATA_BYTES_PER_CONV (4)
+        ESP32C3 || ESP32H2 || ESP32C6 || ESP32S3
+          SOC_ADC_DIGI_RESULT_BYTES        (4)
+          SOC_ADC_DIGI_DATA_BYTES_PER_CONV (4)
+        ESP32C2 
+          is not defined, likley the same as c3
+    */
+    
+    adc_config.conv_frame_size = cfg.buffer_size * cfg.buffer_count * SOC_ADC_DIGI_RESULT_BYTES;
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
+    uint8_t calc_multiple = adc_config.conv_frame_size % SOC_ADC_DIGI_DATA_BYTES_PER_CONV;
+    if (calc_multiple != 0) {
+        adc_config.conv_frame_size += (SOC_ADC_DIGI_DATA_BYTES_PER_CONV - calc_multiple);
+    }
+#endif
+    adc_config.max_store_buf_size = adc_config.conv_frame_size * 2;    
+    LOGI("adc conv_frame_size is %d and max store buf size is %d",adc_config.conv_frame_size, adc_config.max_store_buf_size);
+
+    // Create adc_continuous handle
     esp_err_t err = adc_continuous_new_handle(&adc_config, &adc_handle);
     if (err != ESP_OK) {
       LOGE("adc_continuous_new_handle failed with error: %d", err);
@@ -204,6 +285,7 @@ protected:
       LOGI("adc_continuous_new_handle successful");
     }
 
+    // Boundary checks
     if ((cfg.sample_rate < SOC_ADC_SAMPLE_FREQ_THRES_LOW) ||
         (cfg.sample_rate > SOC_ADC_SAMPLE_FREQ_THRES_HIGH)) {
       LOGE("sample rate: %u can not be set, range: %u to %u",
@@ -224,10 +306,12 @@ protected:
            SOC_ADC_DIGI_MIN_BITWIDTH, SOC_ADC_DIGI_MAX_BITWIDTH);
     }
 
+    // Update bits per sample
     if (!checkBitsPerSample()) {
       return false;
     }
 
+    /// Configure the ADC
     adc_continuous_config_t dig_cfg = {
         .sample_freq_hz = cfg.sample_rate,
         .conv_mode = cfg.adc_conversion_mode,
@@ -258,6 +342,7 @@ protected:
            dig_cfg.adc_pattern[i].bit_width);
     }
 
+    // Initialize ADC
     err = adc_continuous_config(adc_handle, &dig_cfg);
     if (err != ESP_OK) {
       LOGE("adc_continuous_config unsuccessful with error: %d", err);
@@ -265,6 +350,47 @@ protected:
     }
     LOGI("adc_continuous_config successful");
 
+    // Initialize ADC calibration handle
+    //
+    // Calibration is applied to an ADC unit (not per channel). There is ADC1 and ADC2 unit (0,1). 
+    // ADC2 and WiFi share hardware and WiFi has priority. Therefore we prefere ADC1.
+
+    // Lets make sure ADC Channels chosen are on same unit:
+    uint8_t unit=GET_UNIT(cfg.adc_channels[0]);
+    for (int i = 1; i < cfg.channels; i++) {
+      if (unit != GET_UNIT(cfg.adc_channels[i])) {
+        LOGE("error, dont select ADC channels on different ADC units");
+        return false;
+      }
+    }
+    
+    if(adc_cali_handle == NULL){
+      #if ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
+        // curve fitting is preferred
+        adc_cali_curve_fitting_config_t cali_config;
+        cali_config.unit_id  = (adc_unit_t) unit;
+        cali_config.atten    = (adc_atten_t) cfg.adc_attenuation;
+        cali_config.bitwidth = (adc_bitwidth_t) cfg.adc_bit_width;
+        err = adc_cali_create_scheme_curve_fitting(&cali_config, &adc_cali_handle);
+      #elif !defined(CONFIG_IDF_TARGET_ESP32H2)
+        // line fitting
+        adc_cali_line_fitting_config_t cali_config;
+        cali_config.unit_id  = (adc_unit_t) unit;
+        cali_config.atten    = (adc_atten_t) cfg.adc_attenuation;
+        cali_config.bitwidth = (adc_bitwidth_t) cfg.adc_bit_width;
+        err = adc_cali_create_scheme_line_fitting(&cali_config, &adc_cali_handle);
+      #endif
+        if(err != ESP_OK){
+            LOGE("creating cali handle failed for ADC%d with atten %d and bitwidth %d", 
+                unit, cfg.adc_attenuation, cfg.adc_bit_width);
+            return false;
+        } else {
+          LOGI("created cali handle for ADC%d with atten %d and bitwidth %d", 
+                unit, cfg.adc_attenuation, cfg.adc_bit_width);
+        }
+    }
+
+    // Start ADC
     err = adc_continuous_start(adc_handle);
     if (err != ESP_OK) {
       LOGE("adc_continuous_start unsuccessful with error: %d", err);
@@ -275,60 +401,20 @@ protected:
     return true;
   }
 
-  // this is maybe a little bit too much since currently any supported
-  // adc_bit_width leads to int16_t data
   bool checkBitsPerSample() {
-    // adjust bits per sample based on adc bit width setting (multiple of 8)
-    LOGI("cfg.bits_per_sample: %d", cfg.bits_per_sample);
     if (cfg.bits_per_sample == 0) {
-      if (cfg.adc_bit_width <= 8) {
-        cfg.bits_per_sample = 8;
-      } else if (cfg.adc_bit_width <= 16) {
-        cfg.bits_per_sample = 16;
-      } else if (cfg.adc_bit_width <= 24) {
-        cfg.bits_per_sample = 24;
-      } else if (cfg.adc_bit_width <= 32) {
-        cfg.bits_per_sample = 32;
-      } else {
-        cfg.bits_per_sample = 16;
-      }
+      cfg.bits_per_sample = SOC_ADC_DIGI_RESULT_BYTES*8;
+      LOGI("bits per sample set to: %d", cfg.bits_per_sample);
+      return true;
+    } else if (cfg.bits_per_sample == SOC_ADC_DIGI_RESULT_BYTES*8) {
       LOGI("bits per sample: %d", cfg.bits_per_sample);
       return true;
+    } else {
+      LOGE("checking bits per sample error. It should be: %d but is %d", SOC_ADC_DIGI_RESULT_BYTES*8, cfg.bits_per_sample);
+      return false;
     }
-
-    // check bits per sample with requested adc_bit_width
-    switch (cfg.bits_per_sample) {
-      case 8:
-        if (cfg.adc_bit_width > 8) {
-          LOGE("bits_per_sample %d not valid for adc_bit_width %d",
-               cfg.bits_per_sample, cfg.adc_bit_width);
-          return false;
-        }
-        break;
-      case 16:
-        if (cfg.adc_bit_width <= 8 || cfg.adc_bit_width > 16) {
-          LOGE("bits_per_sample %d not valid for adc_bit_width %d",
-               cfg.bits_per_sample, cfg.adc_bit_width);
-          return false;
-        }
-        break;
-      case 24:
-        if (cfg.adc_bit_width <= 16 || cfg.adc_bit_width > 24) {
-          LOGE("bits_per_sample %d not valid for adc_bit_width %d",
-               cfg.bits_per_sample, cfg.adc_bit_width);
-          return false;
-        }
-        break;
-      case 32:
-        if (cfg.adc_bit_width <= 24 || cfg.adc_bit_width >= 32) {
-          LOGE("bits_per_sample %d not valid for adc_bit_width %d",
-               cfg.bits_per_sample, cfg.adc_bit_width);
-          return false;
-        }
-        break; 
-    }
-    return true;
   }
+
 };
 
 /// @brief AnalogAudioStream

--- a/src/AudioAnalog/AnalogConfigESP32V1.h
+++ b/src/AudioAnalog/AnalogConfigESP32V1.h
@@ -4,14 +4,15 @@
 #if defined(USE_ANALOG) && defined(ESP32) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0 , 0) || defined(DOXYGEN)
 
 #include "esp_adc/adc_continuous.h"
+#include "esp_adc/adc_cali_scheme.h"
 
 #if CONFIG_IDF_TARGET_ESP32
-#define ADC_CONV_MODE       ADC_CONV_SINGLE_UNIT_1  //ESP32 only supports ADC1 DMA mode
+#define ADC_CONV_MODE       ADC_CONV_SINGLE_UNIT_1  // ADC2 and Wifi work together
 #define ADC_OUTPUT_TYPE     ADC_DIGI_OUTPUT_FORMAT_TYPE1
 #define ADC_CHANNELS        {ADC_CHANNEL_6, ADC_CHANNEL_7}
 #define HAS_ESP32_DAC
 #elif CONFIG_IDF_TARGET_ESP32S2
-#define ADC_CONV_MODE       ADC_CONV_BOTH_UNIT // might only work with single unit
+#define ADC_CONV_MODE       ADC_CONV_SINGLE_UNIT_1 // ADC2 competes with WiFi and WiFi has priority, ADC_CONV_BOTH_UNIT
 #define ADC_OUTPUT_TYPE     ADC_DIGI_OUTPUT_FORMAT_TYPE2
 #define ADC_CHANNELS        {ADC_CHANNEL_2, ADC_CHANNEL_3}
 #define HAS_ESP32_DAC
@@ -20,9 +21,9 @@
 #define ADC_OUTPUT_TYPE     ADC_DIGI_OUTPUT_FORMAT_TYPE2
 #define ADC_CHANNELS        {ADC_CHANNEL_2, ADC_CHANNEL_3}
 #elif CONFIG_IDF_TARGET_ESP32S3
-#define ADC_CONV_MODE       ADC_CONV_BOTH_UNIT // might only work with single unit
+#define ADC_CONV_MODE       ADC_CONV_SINGLE_UNIT_1 // ADC2 competes with WiFi and WiFi has priority
 #define ADC_OUTPUT_TYPE     ADC_DIGI_OUTPUT_FORMAT_TYPE2
-#define ADC_CHANNELS        {ADC_CHANNEL_2, ADC_CHANNEL_3}
+#define ADC_CHANNELS        {ADC_CHANNEL_2, ADC_CHANNEL_3} // These are the I2C SDA and SCL pins on Adafruit ESP32-S3 feather , Channel 4&5 might be better
 #endif
 
 #ifdef HAS_ESP32_DAC
@@ -69,6 +70,7 @@ class AnalogConfigESP32V1 : public AudioInfo {
       sample_rate = 44100;
       adc_bit_width  = 12;
       channels =  2;
+      bits_per_sample = SOC_ADC_DIGI_RESULT_BYTES*8;
       rx_tx_mode = rxtxMode;
       if (rx_tx_mode == RX_MODE) {
         LOGI("I2S_MODE_ADC_BUILT_IN");


### PR DESCRIPTION
This is an attempt to update the ESP32 ADC module to adjust to "bytes per conv" and "result bytes" which are different between ESP32 models. For example some older models create 2 bytes per conversion in the DMA buffer, others create 4 bytes.
I also attempted to apply the ESP32 calibration module to the recorded data.
If the measure-sink reports bytes per second per channel, the modifications might be correctly working. 
I have not tested adc recording of known data yet.
I used arduino-esp32 as reference.
ESP32 throughput scales all the way to 2 MHz sampling rate.

Modifications:

examples
- through put measurement example for ADC
- 
AnalogAudioESP32V1
- Added ADC calibration module
- Use of SOC_ADC_DIGI_RESULT_BYTE
- Use of SOC_ADC_DIGI_DATA_BYTES_PER_CON
- Updates and additions to readBytes
- Simplification of checkBitsPerSample

AnalogConfigESP32V1
- Use only one ADC unit, ensure that channels are on same ADC unit
- bits_per_sample is set to SOC_ADC_DIGI_RESULT_BYTES*8

