### PR TITLE
save AudioServer.begin() converter parameter

### DIFF
--- a/src/AudioHttp/AudioServer.h
+++ b/src/AudioHttp/AudioServer.h
@@ -299,6 +299,7 @@ class AudioEncoderServer  : public AudioServer {
             audio_info.sample_rate = sample_rate;
             audio_info.channels = channels;
             audio_info.bits_per_sample = bits_per_sample;
+            this->converter_ptr = converter;
             encoder->setAudioInfo(audio_info);
             //encoded_stream.begin(&client_obj, encoder);
             encoded_stream.setInput(&client_obj);
@@ -318,6 +319,7 @@ class AudioEncoderServer  : public AudioServer {
             TRACED();
             this->in = &in;
             this->audio_info = info;
+            this->converter_ptr = converter;
             encoder->setAudioInfo(audio_info);
             //encoded_stream.begin(&client_obj, encoder);
             encoded_stream.setInput(&client_obj);


### PR DESCRIPTION
took me a while to figure out why the second channel of my INMP441 didn't work :)

to find this I created an example similar to streams-i2s-webserver_wav. Maybe you are interested to add it somewhere? It works great with the INMP441.

```c++
/**
 * Enhanced streams-i2s-webserver_wav.ino optimized for INMP441
 * 
 * - Features a flexible mono to multi channel converter
 * - #define COPY_LOG_OFF or change AudioLogger level to Warning to avoid hickups
 * - Adjust pin numbers in setup() according to your board
 * - Works fine with Chrome, my INMP441 and git main of ESP32 pio platform and arduino-audio-tools as of Nov 2023
 * - Works with I2S_MSB_FORMAT (datasheet), and also with I2S_STD_FORMAT, I2S_PHILIPS_FORMAT or I2S_LEFT_JUSTIFIED_FORMAT
 * 
 * have fun, JoBa-1
 */

#include "AudioTools.h"

// Contains MY_SSID and MY_PASS 
#include "cred.h"


/**
 * @brief Extend channel Cx value of type T shifted by S bits to all Cn channels
 */
template<typename T, size_t Cn, size_t Cx, size_t S>
class ExtendChan : public BaseConverter {
  public:
  ExtendChan() : _max_val(0), _counter(0), _prev_ms(0) {}

  size_t convert(uint8_t *src, size_t size) {
    T *chan = (T*)src;
    size_t samples = (size / Cn) / sizeof(T);
    for( size_t s=0; s<samples; s++ ) {
      chan[s*Cn+Cx] = (Cx < Cn) ? chan[s*Cn+Cx] << S : 0;

      for( size_t c=0; c<Cn; c++ ) {
        if( c != Cx ) {
          chan[s*Cn+c] = chan[s*Cn+Cx];
        }
      }

      if( _max_val < chan[s*Cn] ) { 
          _max_val = chan[s*Cn];
      }

      _counter++;
      uint32_t now = millis();
      if( now - _prev_ms > 1000 ) { 
        _prev_ms = now;
        LOGI("ExtendChan samples: %u, amplitude: %d", _counter, _max_val);
        _max_val = 0;
      }
    }
    return samples * Cn * sizeof(T);
  }

  private:
  T _max_val;
  uint32_t _counter;
  uint32_t _prev_ms;
};


// Type of a channel sample, number of channels and sample rate
typedef int32_t in_chan_t;            // received sample size, see INMP441 datasheet
typedef int16_t out_chan_t;           // as supported by AudioWAVServer
constexpr size_t NumChan = 2;         // received channels, see INMP441 datasheet
constexpr size_t SampleRate = 44100;  // lower gives fast playback and gaps
constexpr size_t MicChanBits = 24;    // actually used bits, see INMP441 datasheet


constexpr size_t InChanBytes = sizeof(in_chan_t);
constexpr size_t OutChanBytes = sizeof(out_chan_t);

constexpr size_t InChanBits = InChanBytes * CHAR_BIT;
constexpr size_t OutChanBits = OutChanBytes * CHAR_BIT;

constexpr size_t MicShift = ((InChanBits - MicChanBits) * OutChanBits) / InChanBits;


AudioInfo in(SampleRate, NumChan, InChanBits);
AudioInfo out(SampleRate, NumChan, OutChanBits);

I2SStream i2s;
FormatConverterStream cvt(i2s);  // INMP441 delivers 32bit, AudioWAVServer needs 16bit
ExtendChan<out_chan_t, NumChan, 0, MicShift> extend;  // one channel has no data, see INMP441 datasheet
AudioWAVServer srv(MY_SSID, MY_PASS);  // Streaming with Chrome works, Firefox downloads.


void setup() {
  Serial.begin(BAUDRATE);
  AudioLogger::instance().begin(Serial, AudioLogger::Info);

  auto cfg = i2s.defaultConfig(RX_MODE);
  cfg.i2s_format = I2S_MSB_FORMAT;
  cfg.copyFrom(in);

  cfg.pin_data = 21;
  cfg.pin_ws = 17;
  cfg.pin_bck = 16;
 
  i2s.begin(cfg);
  cvt.begin(in, out);
  srv.begin(cvt, cfg, &extend);
}


void loop() {
  srv.copy();  
}

```