### PR TITLE
Fixed incorrect copier output

### DIFF
--- a/examples/examples-stream/streams-i2s-a2dp/streams-i2s-a2dp.ino
+++ b/examples/examples-stream/streams-i2s-a2dp/streams-i2s-a2dp.ino
@@ -12,7 +12,7 @@
 
 I2SStream i2sStream;                            // Access I2S as stream
 A2DPStream a2dpStream;                          // access A2DP as stream
-StreamCopy copier(i2sStream, i2sStream); // copy i2sStream to a2dpStream
+StreamCopy copier(a2dpStream, i2sStream); // copy i2sStream to a2dpStream
 ConverterFillLeftAndRight<int16_t> filler(LeftIsEmpty); // fill both channels
 
 // Arduino Setup


### PR DESCRIPTION
Copier output was erroneously set to send audio from the I2S input back into the I2S input