### PR TITLE
ESP32 continuous ADC & examples

### DIFF
--- a/examples/README_ESP32.md
+++ b/examples/README_ESP32.md
@@ -1,0 +1,141 @@
+# ESP32 Configuration
+
+If you are using ESP32 by Espressif Systems version 3.0.0 and later, audio tools will use the new adc_continuous API.
+This board option is under development and changing.
+
+For the adc_continuous API, audio tools provides the following options:
+
+- **sample_rate** (per channel), the effective ADC sampling rate is the number of channels x sample rate and can be:
+    - ESP32: 20kHz to 2MHz
+    - other ESP32 eg. ESP32S3 611Hz to 83kHz
+
+for example:
+
+    -       306
+    -     4,000
+    -     5,000
+    -     8,000
+    -    10,000
+    -    11,025
+    -    16,000
+    -    20,000
+    -    22,050
+    -    40,000
+    -    44,100
+    -    48,000
+    -    88,200
+    -    96,000
+    -   176,400
+    -   192,200
+    -   352,800
+    -   384,000
+    -   500,000
+    - 1,000,000
+
+- **adc_bit_with**
+    - 9, 10, 11, 12 depending on ESP32 model
+    - audio stream is int16_t
+- **adc_calibration_active**: values measured are in mV
+- **is_auto_center_read**: subtraction of current estimated average from samples
+- **adc_attenuation**:
+
+    | attenuation     | range   | accurate range |
+    | ------------    | --------| -------------- |
+    | ADC_ATTEN_DB_0  | 0..1.1V | 100-950mV      |
+    | ADC_ATTEN_DB_2_5| 0..1.5V | 100-1250mV     |
+    | ADC_ATTEN_DB_6  | 0..2.2V | 150-1750mV     |
+    | ADC_ATTEN_DB_11 | 0..3.9V | 150-2450mV     |
+   
+- **channels**:
+    - mono = 1  
+    - stereo = 2
+- **adc_channels**: defining the channels (only channels on ADC unit 1 are supported) e.g.:
+    - A3 on Sparkfun ESP32 Thing Plus is ADC_CHANNEL_3
+    - A4 on Sparkfun ESP32 Thing Plus is ADC_CHANNEL_0
+    - D5 on Adafruit ESP32-S3 is ADC_CHANNEL_4
+    - D6 on Adafruit ESP32-S3 is ADC_CHANNEL_5
+
+## Example Configuration
+```
+auto adcConfig = adc.defaultConfig(RX_MODE);
+adcConfig.sample_rate = 44100;
+adcConfig.adc_bit_width = 12;
+adcConfig.adc_calibration_active = true;
+adcConfig.is_auto_center_read = false;
+adcConfig.adc_attenuation = ADC_ATTEN_DB_11; 
+adcConfig.channels = 2;
+adcConfig.adc_channels[0] = ADC_CHANNEL_4; 
+adcConfig.adc_channels[1] = ADC_CHANNEL_5;
+```
+
+## ADC unit 1 channels on common ESP32 boards
+Audio tools supports ADC Unit 1 only.
+
+### Sparkfun ESP32 Thing Plus (ESP32)
+- A2, ADC1_CH6
+- A3, ADC1_CH3 
+- A4, ADC1_CH0 
+- 32, ADC1_CH4
+- 33, ADC1_CH5
+
+### Sparkfun ESP32 Qwiic Pocket Development (ESP32C6)
+- 2, ADC1_CH2
+- 3, ADC1_CH3
+- 4, ADC1_CH4
+- 5, ADC1_CH5
+
+### ESP32-C6-DevKit
+- 4, ADC1_CH4
+- 5, ADC1_CH5
+- 6, ADC1_CH6
+- 7, ADC1_CH0
+- 0, ADC1_CH1
+- 2, ADC1_CH2
+- 3, ADC1_CH3
+
+### ESP32-H2-DevKit
+- 1, ADC1_CH0
+- 2, ADC1_CH1
+- 3, ADC1_CH2
+- 4, ADC1_CH3
+- 5, ADC1_CH4
+
+### ESP32­-S3­-DevKit
+- 1,  ADC1_CH0
+- 2,  ADC1_CH1
+- 4,  ADC1_CH3
+- 5,  ADC1_CH4
+- 6,  ADC1_CH5
+- 7,  ADC1_CH6
+- 8,  ADC1_CH7
+- 3,  ADC1_CH2
+- 9,  ADC1_CH8
+- 10, ADC1_CH9
+
+### ESP32-C3-DevKit
+-  4, IO2, ADC1_CH2
+-  5, IO3, ADC1_CH3
+-  9, IO0, ADC1_CH0
+- 10, IO1, ADC1_CH1
+- 11, IO4, ADC1_CH4
+
+### Adafruit ESP32 Feather V2
+- D32, ADC1_CH4
+- D33, ADC1_CH5
+-  A2, ADC1_CH6
+-  A3, ADC1_CH3
+-  A4, ADC1_CH0
+- D37, ADC1_CH1
+
+### Adafruit ESP32-S3 Feather
+-  D5, ADC1_CH4
+-  D6, ADC1_CH5
+-  D9, ADC1_CH8
+- D10, ADC1_CH9
+-  A5, ADC1_CH7
+
+### Adafruit QT Py ESP32-C3
+- A0, ADC1-CH4
+- A1, ADC1-CH3
+- A2, ADC1-CH1
+- A3, ADC1-CH0

--- a/examples/examples-basic-api/base-adc-average-mono-serial/base-adc-average-mono-serial.ino
+++ b/examples/examples-basic-api/base-adc-average-mono-serial/base-adc-average-mono-serial.ino
@@ -1,0 +1,86 @@
+/**
+ * @file base-adc-average-mono-serial.ino
+ * @brief Attempts down sampling with binning of a mono audio signal by AVG_LEN
+ * @author Urs Utzinger
+ * @copyright GPLv3
+ **/
+
+#include "Arduino.h"
+#include "AudioTools.h"
+
+// On board analog to digital converter
+AnalogAudioStream analog_in; 
+
+// Serial terminal output
+CsvStream<int16_t> serial_out(Serial);
+
+#define BAUD_RATE   500000
+#define SAMPLE_RATE 44100
+#define BUFFER_SIZE 256
+#define AVG_LEN 64
+#define BYTES_PER_SAMPLE sizeof(int16_t)
+
+// buffer to read samples and store the average samples
+int16_t buffer[BUFFER_SIZE];
+
+void setup() {
+  
+  delay(3000); // wait for serial to become available
+
+  // Serial Interface
+  Serial.begin(BAUD_RATE);
+
+  // Include logging to serial
+  AudioLogger::instance().begin(Serial, AudioLogger::Error); // Debug, Warning, Info, Error
+  
+  // Start ADC input
+  Serial.println("Starting ADC...");
+  auto adcConfig = analog_in.defaultConfig(RX_MODE);
+  adcConfig.sample_rate = SAMPLE_RATE;
+  adcConfig.channels = 1; 
+
+  // For ESP32 by Espressif Systems version 3.0.0 and later:
+  // see examples/README_ESP32.md
+  // adcConfig.sample_rate = 44100;
+  // adcConfig.adc_bit_width = 12;
+  // adcConfig.adc_calibration_active = true;
+  // adcConfig.is_auto_center_read = false;
+  // adcConfig.adc_attenuation = ADC_ATTEN_DB_11; 
+  // adcConfig.channels = 1;
+  // adcConfig.adc_channels[0] = ADC_CHANNEL_4; 
+
+  analog_in.begin(adcConfig);
+
+  // Start Serial Output CSV
+  Serial.println("Starting Serial Out...");
+  auto csvConfig = serial_out.defaultConfig();
+  csvConfig.sample_rate = SAMPLE_RATE/AVG_LEN;
+  csvConfig.channels = 1;
+  csvConfig.bits_per_sample = 16;
+  serial_out.begin(csvConfig);
+}
+
+
+void loop() {
+
+  // Read the values from the ADC buffer to local buffer
+  size_t bytes_read   = analog_in.readBytes((uint8_t*) buffer, BUFFER_SIZE * BYTES_PER_SAMPLE); // read byte stream and  cast to destination type
+  size_t samples_read = bytes_read/BYTES_PER_SAMPLE; 
+  size_t avg_samples  = samples_read/AVG_LEN;
+
+  // Average the samples over AVG_LEN
+  int32_t sum; // register to hold summed values
+  int16_t *sample = (int16_t*) buffer; // sample pointer (input)
+  int16_t *avg = (int16_t*) buffer; // result pointer (output)
+  // each time we access a sample we increment sample pointer
+  for(uint16_t j=0; j<avg_samples; j++){
+    sum = *sample++; // initialize sum
+    for (uint16_t i=1; i<AVG_LEN; i++){
+      sum += *sample++; // sum the samples
+    }
+    // compute average and store in output buffer
+    *avg++ = (int16_t) (sum/AVG_LEN); 
+  }
+
+  serial_out.write((uint8_t*)buffer, avg_samples*BYTES_PER_SAMPLE); // stream to output as byte type
+}

--- a/examples/examples-basic-api/base-adc-measure/Readme.md
+++ b/examples/examples-basic-api/base-adc-measure/Readme.md
@@ -1,0 +1,60 @@
+# ESP32 Analog to Digital Conversion Throughput using Continuous ADC API
+
+Data is reported in bytes per second when using a single ADC unit and two A/D channels.
+When each channel is measured with 4,000 samples per second the ADC is running at 8,000 samples per second as it multiplexes between the two channels.
+
+The maximum sampling frequency depends on the ESP32 model.
+
+The older ESP32 models can convert up to 2 Million samples per second, however there is discrepancy between the expected and effective throughput of about 20%.
+
+The library creates int16_t datatype which is 2 bytes per sample.
+
+## Adafruit Feather ESP32-S3 2MB PSRAM
+```
+    
+   SPS  :  expected,  measured
+      150: error, sample rate eff: 300, range: 611 to 83,333
+      306:    1,224,     1,000
+    4,000:   16,000,    16,000
+    8,000:   32,000,    32,000   
+   11,025:   44,100,    44,000
+   16,000:   64,000,    64,000
+   20,000:   80,000,    80,000
+   22,050:   88,200,    89,000
+   40,000:  160,000,   161,000
+   44,100: error, sample rate eff: 88,200, range: 611 to 83,333
+```
+
+## Sparkfun ESP32 WROOM Plus C
+```
+  Data: bytes per second, single unit, two channels
+   SPS/CH  expected,  measured % of expected
+    5000:  error, sample rate eff: 10000, range: 20000 to 2000000
+   10000:    40,000,    32,000
+   22050:    88,200,    72,000
+   44100:   176,400,   144,000
+   88200:   352,800,   157,000
+  500000: 2,000,000, 1,635,000
+ 1000000: 4,000,000, 3,271,000
+```
+
+## DOIT ESP32 DEVKIT V1
+```
+  Data: bytes per second, single unit, two channels
+   SPS  :  expected,  measured 80% of expected
+    5000:  error, sample rate: 5000, range: 10000 to 1000000
+   10000:    40,000,    32,000
+   20000:    80,000,    64,000
+   22050:    88,200,    72,000
+   44100:   176,400,   144,000
+   48000:   192,000,   156,000
+   88200:   352,800,   288,000
+   96000:   384,000,   313,000
+  176400:   705,600,   576,000
+  192200:   768,800,   628,000
+  352800: 1,411,200, 1,153,000
+  384000: 1,536,000, 1,256,000
+  500000: 2,000,000, 1,635,000
+ 1000000: 4,000,000, 3,271,000
+ 1500000: error, sample rate: 1500000, range: 10000 to 1000000
+```

--- a/examples/examples-basic-api/base-adc-measure/base-adc-measure.ino
+++ b/examples/examples-basic-api/base-adc-measure/base-adc-measure.ino
@@ -7,7 +7,7 @@
 #include "AudioTools.h"
 
 // On board analog to digital converter
-AnalogAudioStream analog_in;
+AnalogAudioStream analog_in; 
 
 // Measure throughput
 MeasuringStream measure(1000, &Serial);
@@ -16,53 +16,38 @@ MeasuringStream measure(1000, &Serial);
 StreamCopy copier(measure, analog_in);
 
 void setup() {
+
+  delay(3000); // wait for serial to become available
+
   // Serial Interface
   Serial.begin(115200);
   // Include logging to serial
-  AudioLogger::instance().begin(Serial, AudioLogger::Info); // Warning, INfo
-
-  // Start ADC input
-  Serial.println("Starting ADC...");
+  AudioLogger::instance().begin(Serial, AudioLogger::Info); //Warning, Info, Error, Debug
+  
+  // Configure ADC input
   auto adcConfig = analog_in.defaultConfig(RX_MODE);
-  adcConfig.sample_rate = 2000000;
-  // adcConfig.adc_bit_width = 12;  // platform & release dependent parameters
+
+  // For ESP32 by Espressif Systems version 3.0.0 and later 
+  // see examples/README_ESP32.md
+  // adcConfig.sample_rate = 22050;
+  // adcConfig.adc_bit_width = 12;
+  // adcConfig.adc_calibration_active = true;
+  // adcConfig.is_auto_center_read = false;
+  // adcConfig.adc_attenuation = ADC_ATTEN_DB_11; 
+  // adcConfig.channels = 2;
+  // adcConfig.adc_channels[0] = ADC_CHANNEL_4; 
+  // adcConfig.adc_channels[1] = ADC_CHANNEL_5;
+
+  adcConfig.sample_rate = 44100; // per channel
+
+  Serial.println("Starting ADC...");
   analog_in.begin(adcConfig);
 
   // Start Measurements
-  AudioLogger::instance().begin(Serial, AudioLogger::Warning); // Warning, INfo
+  AudioLogger::instance().begin(Serial, AudioLogger::Warning); //Warning, Debug, Info, Error
   Serial.println("Starting through put measurement...");
 }
 
-void loop() { copier.copy(); }
-
-/* Adafruit Feather ESP32-S3 2MB PSRAM
-  Data: bytes per second, single unit
-   SPS  :  expected,  measured (might be per channel)
-    8,000:   64,000,    32,000
-   11,025:   88,200,    44,000
-   16,000:  128,000,    64,000
-   20,000:  160,000,    80,000
-   22,050:  176,400,    88,000
-   44,100:  352,800,   179,000
-   48,000:  384,000,   192,000
-   88,200:    error, sample rate: 88200 error, range: 611 to 83333
-*/
-
-/* DOIT ESP32 DEVKIT V1
-  Data: bytes per second, single unit
-   SPS  :  expected,  measured (might be per channel) 80% of expected
-   16000:  error, sample rate: 16000 warning, range: 20000 to 2000000
-   20000:    80,000,    32,000
-   22050:    88,200,    36,000
-   44100:   176,400,    72,000
-   48000:   192,000,    77,000
-   88200:   352,800,   144,000
-   96000:   384,000,   157,000
-  176400:   704,000,   288,000
-  192200:   768,800,   314,000
-  352800: 1,411,200,   576,000
-  384000: 1,536,000,   627,000
- 1000000: 4,000,000, 1,640,000
- 1500000: 6,000,000, 2,455,000
- 2000000: 8,000,000, 3,271,000
-*/
+void loop() {
+  copier.copy(); 
+}

--- a/examples/examples-basic-api/base-adc-serial/base-adc-serial.ino
+++ b/examples/examples-basic-api/base-adc-serial/base-adc-serial.ino
@@ -23,33 +23,27 @@ ConverterScaler<int16_t> scaler(1.0, -26427, 32700 );
 
 // Arduino Setup
 void setup(void) {
-  delay(3000); // Give time to boot
+
+  delay(3000); // wait for serial to become available
+
   Serial.begin(115200);
   // Include logging to serial
-  AudioLogger::instance().begin(Serial, AudioLogger::Info); //Warning, Info
+  AudioLogger::instance().begin(Serial, AudioLogger::Info); //Warning, Info, Error, Debug
   Serial.println("starting ADC...");
   auto adcConfig = adc.defaultConfig(RX_MODE);
-  adcConfig.sample_rate = 44100;
-  // do not set bits_per_sample as that is configured based on adc_bit_with
-  adcConfig.adc_bit_width = 12; // this will result in 16 bits_per_sample
-  adc.begin(adcConfig);
 
-  // delay(100);
-  // if (adcConfig.rx_tx_mode == RX_MODE){
-  //   Serial.println("Using RX Mode (ADC)");
-  // }
-  // else if (adcConfig.rx_tx_mode == TX_MODE) {
-  //   Serial.println("Using TX Mode (DAC)");
-  // }
-  // Serial.printf("sample_rate is: %u\n", adcConfig.sample_rate);
-  // Serial.printf("bits_per_sample is: %u\n", adcConfig.bits_per_sample);
-  // Serial.printf("adc_attenuation is: %u\n", adcConfig.adc_attenuation);
-  // Serial.printf("adc_bit_width is: %u\n", adcConfig.adc_bit_width);
-  // Serial.printf("adc mode is: %u\n", adcConfig.adc_conversion_mode);
-  // Serial.printf("adc format is: %u\n", adcConfig.adc_output_type);
-  // for(int i=0; i<adcConfig.channels; i++) {
-  //   Serial.printf("channel[%d] is on pin: %u\n", i, adcConfig.adc_channels[i]);
-  // }
+  // For ESP32 by Espressif Systems version 3.0.0 and later:
+  // see examples/README_ESP32.md
+  // adcConfig.sample_rate = 44100;
+  // adcConfig.adc_bit_width = 12;
+  // adcConfig.adc_calibration_active = true;
+  // adcConfig.is_auto_center_read = false;
+  // adcConfig.adc_attenuation = ADC_ATTEN_DB_11; 
+  // adcConfig.channels = 2;
+  // adcConfig.adc_channels[0] = ADC_CHANNEL_4; 
+  // adcConfig.adc_channels[1] = ADC_CHANNEL_5;
+
+  adc.begin(adcConfig);
 }
 
 // Arduino loop - repeated processing 

--- a/src/AudioAnalog/AnalogConfigESP32V1.h
+++ b/src/AudioAnalog/AnalogConfigESP32V1.h
@@ -5,16 +5,17 @@
 
 #include "esp_adc/adc_continuous.h"
 #include "esp_adc/adc_cali_scheme.h"
+#include "esp32-hal-periman.h"
 
 #if CONFIG_IDF_TARGET_ESP32
-#  define ADC_CONV_MODE       ADC_CONV_SINGLE_UNIT_1  // ADC2 and Wifi work together
+#  define ADC_CONV_MODE       ADC_CONV_SINGLE_UNIT_1
 #  define ADC_OUTPUT_TYPE     ADC_DIGI_OUTPUT_FORMAT_TYPE1
 #  define ADC_CHANNELS        {ADC_CHANNEL_6, ADC_CHANNEL_7}
 #  define AUDIO_ADC_GET_CHANNEL(p_data)     ((p_data)->type1.channel)
 #  define AUDIO_ADC_GET_DATA(p_data)        ((p_data)->type1.data)
 #  define HAS_ESP32_DAC
 #elif CONFIG_IDF_TARGET_ESP32S2
-#  define ADC_CONV_MODE       ADC_CONV_SINGLE_UNIT_1 // ADC2 competes with WiFi and WiFi has priority, ADC_CONV_BOTH_UNIT
+#  define ADC_CONV_MODE       ADC_CONV_SINGLE_UNIT_1
 #  define ADC_OUTPUT_TYPE     ADC_DIGI_OUTPUT_FORMAT_TYPE2
 #  define AUDIO_ADC_GET_CHANNEL(p_data)     ((p_data)->type2.channel)
 #  define AUDIO_ADC_GET_DATA(p_data)        ((p_data)->type2.data)
@@ -27,15 +28,15 @@
 #  define AUDIO_ADC_GET_DATA(p_data)        ((p_data)->type2.data)
 #  define ADC_CHANNELS        {ADC_CHANNEL_2, ADC_CHANNEL_3}
 #elif CONFIG_IDF_TARGET_ESP32S3
-#  define ADC_CONV_MODE       ADC_CONV_SINGLE_UNIT_1 // ADC2 competes with WiFi and WiFi has priority
+#  define ADC_CONV_MODE       ADC_CONV_SINGLE_UNIT_1
 #  define ADC_OUTPUT_TYPE     ADC_DIGI_OUTPUT_FORMAT_TYPE2
 #  define AUDIO_ADC_GET_CHANNEL(p_data)     ((p_data)->type2.channel)
 #  define AUDIO_ADC_GET_DATA(p_data)        ((p_data)->type2.data)
-#  define ADC_CHANNELS        {ADC_CHANNEL_2, ADC_CHANNEL_3} // These are the I2C SDA and SCL pins on Adafruit ESP32-S3 feather , Channel 4&5 might be better
+#  define ADC_CHANNELS        {ADC_CHANNEL_2, ADC_CHANNEL_3} // or channel 4 & 5
 #endif
 
-#define GET_ADC_UNIT_FROM_CHANNEL(x) ((x >> 3) & 0x1)
-
+// #define GET_ADC_UNIT_FROM_CHANNEL(x) ((x >> 3) & 0x1)
+#  define ADC_UNIT            ADC_UNIT_1 // continuous ADC API only supports ADC1
 
 #ifdef HAS_ESP32_DAC
 #  include "driver/dac_continuous.h"


### PR DESCRIPTION
Included further components of https://github.com/espressif/arduino-esp32/blob/master/cores/esp32/esp32-hal-adc.c into AnalogAudioESP32V!.h

- Initialize pins on periman
- Additional boundary checks
- Fixed ADC_UNIT to unit 1.
- Confirm that pins/channels are present on that unit.

- Updated examples "base-adc-serial" and "base-adc-measure" to work on other architectures.
- Added base-adc-average-mono-serial where readings are averaged and send to serial at lower data rate.
- Added ESP32 readme to examples-folder explaining how to use the continuous ADC options.

It took me a while to get back to update the examples as I wanted to first create a serial plotter that can visualize the audio signals in real-time: https://github.com/uutzinger/SerialUI It's written in python and one can visualize data better than in Arduino IDE.