### PR TITLE
resolve linker conflict with AudioFFTNotes

### DIFF
--- a/src/AudioLibs/AudioFFT.h
+++ b/src/AudioLibs/AudioFFT.h
@@ -13,7 +13,7 @@ namespace audio_tools {
 
 // forward declaration
 class AudioFFTBase;
-MusicalNotes AudioFFTNotes;
+static MusicalNotes AudioFFTNotes;
 
 /**
  * @brief Result of the FFT


### PR DESCRIPTION
Using the arduino-audio-tools in a C++ program with multiple .h and .cpp  files lead to a linker error: The instance variable 'AudioFFTNotes' was defined multiple times depending on the include files. In order to instruct the compiler and linker to use only one definition of AudioFFTNotes, the keyword 'static' was added to the corresponding definition in AudioFFT.h
