### PR TITLE
move int24_t into namespace (make it compile within ESPHome)

### DIFF
--- a/src/AudioConfig.h
+++ b/src/AudioConfig.h
@@ -737,11 +737,13 @@ typedef WiFiClient WiFiClientSecure;
 // select int24 implementation
 #include "AudioBasic/Int24_3bytes_t.h"
 #include "AudioBasic/Int24_4bytes_t.h"
+namespace audio_tools {
 #ifdef USE_3BYTE_INT24
 using int24_t = audio_tools::int24_3bytes_t;
 #else
 using int24_t = audio_tools::int24_4bytes_t;
 #endif
+}
 
 #ifndef ESP32
 #define ESP_IDF_VERSION_VAL(a, b , c) 0


### PR DESCRIPTION
I had issues loading this library from [ESPHome](https://esphome.io/)

```
.piolibdeps/audio-test/arduino-audio-tools/src/AudioTools/AudioTypes.h:261:42: error: reference to 'int24_t' is ambiguous
[...]
src/esphome/core/datatypes.h:38:8: note: candidates are: 'struct esphome::int24_t'
[...]
.piolibdeps/audio-test/arduino-audio-tools/src/AudioTools/AudioTypes.h:261:42: error: 'int24_t' has not been declared
[...]
```

And many more subsequent error messages inherited from that.

This PR moves 'our' int24_t into the audio_tools namespace so it doesn't clash with other definitions.

- [x] tested this compiles on esphome for ESP32
- [x] tested this compiles and still runs without esphome