### PR TITLE
fix: freertos include paths

### DIFF
--- a/src/Concurrency/QueueRTOS.h
+++ b/src/Concurrency/QueueRTOS.h
@@ -1,8 +1,8 @@
 #pragma once
 #include "AudioConfig.h"
 #ifdef USE_CONCURRENCY
-#include "FreeRTOS.h"
-#include "queue.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
 
 namespace audio_tools {
 


### PR DESCRIPTION
We pulled a project today based on the esp32 today and it failed because these two paths we're not fully qualified