### PR TITLE
Fixed uninitialized warning

### DIFF
--- a/src/AudioI2S/I2SConfigESP32.h
+++ b/src/AudioI2S/I2SConfigESP32.h
@@ -74,7 +74,7 @@ class I2SConfigESP32 : public AudioInfo {
     int pin_ws = PIN_I2S_WS;
     int pin_bck = PIN_I2S_BCK;
     int pin_data; // rx or tx pin dependent on mode: tx pin for RXTX_MODE
-    int pin_data_rx; // rx pin for RXTX_MODE
+    int pin_data_rx = -1; // rx pin for RXTX_MODE
     int pin_mck = PIN_I2S_MCK;
     int buffer_count = I2S_BUFFER_COUNT;
     int buffer_size = I2S_BUFFER_SIZE;


### PR DESCRIPTION
With -Werror=uninitialized on the xtensa-esp32-elf-g++ compiler this warning occurs:

```
.pio/libdeps/lolin32_lite/audio-tools/src/AudioI2S/I2SConfigESP32.h: In function 'void sample_rate_changed(uint16_t)':
.pio/libdeps/lolin32_lite/audio-tools/src/AudioI2S/I2SConfigESP32.h:46:9: warning: 'i2sc.audio_tools::I2SConfigESP32::pin_data_rx' is used uninitialized in this function [-Wuninitialized]
         I2SConfigESP32(const I2SConfigESP32 &cfg) = default;
         ^~~~~~~~~~~~~~
```

It is mitigated by picking a default value for `pin_data_rx`.