### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ You can download the library as zip and call include Library -> zip library. Or 
 
 ```
 cd  ~/Documents/Arduino/libraries
-git clone https://github.com/pschatzmann/arduino-audio-tools.git
+git clone https://github.com/pschatzmann/arduino-audio-driver.git
 ```
 
 I recommend to use git because you can easily update to the latest version just by executing the ```git pull``` command in the project folder.


### PR DESCRIPTION
This change resolves an issue where new users would receive an error when first trying to compile some example code.  The error they would receive is similar to this one:
fatal error: AudioBoard.h: No such file or directory 2 | #include "AudioBoard.h"

This change ensures that new users will install the correct library.