### PR TITLE
add library information for PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,22 @@
+{
+    "name": "arduino-audio-tools",
+    "version": "0.9.8",
+    "description": "Arduino Audio Tools (Music Player, Music Recorder supporting I2S, Microphones, DAC, ADC, A2DP, Url), MP3 Player, AAC Player contain some useful audio processing classes",
+    "keywords": "music, microphone, i2s, pdm, mp3, aac",
+    "repository":
+    {
+      "type": "git",
+      "url": "https://github.com/pschatzmann/arduino-audio-tools"
+    },
+    "authors":
+    [
+      {
+        "name": "Phil Schatzmann",
+        "url": "www.pschatzmann.ch",
+        "maintainer": true
+      }
+    ],
+    "license": "GPL-3.0-or-later",
+    "frameworks": "Arduino",
+    "platforms": "*"
+  }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=audio-tools
-version=0.9.6
+version=0.9.8
 author=Phil Schatzmann
 maintainer=Phil Schatzmann
 sentence=Some useful audio processing classes


### PR DESCRIPTION
To be able to install the library from within PlatformIO, an information file is required which is added in this PR. If this PR is merged, the library also need to be published as described [here](https://docs.platformio.org/en/latest/librarymanager/creating.html#publishing). In case of success, we should also add installation instructions to the following pages I found (feel free to add more):

https://github.com/pschatzmann/arduino-audio-tools/wiki/Working-with-PlatformIO
https://github.com/pschatzmann/arduino-audio-tools/blob/main/README.md
