### PR TITLE
Added file size to WAV header parse.

### DIFF
--- a/src/AudioCodecs/CodecWAV.h
+++ b/src/AudioCodecs/CodecWAV.h
@@ -76,6 +76,7 @@ class WAVHeader {
         seek(length, SEEK_CUR);
         continue;
       }
+      headerInfo.file_size = length;
       tag2 = read_tag();
       length -= 4;
       if (tag2 != TAG('W', 'A', 'V', 'E')) {


### PR DESCRIPTION
Hi,

The WAVHeader::parse() function appears to be missing assignment of the file size, since it always returns 0. Added it to the parse() function.

Best regards,
djpearman