### PR TITLE
fix: Missing MusicalNotes.h import in FFT

### DIFF
--- a/src/AudioLibs/AudioFFT.h
+++ b/src/AudioLibs/AudioFFT.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AudioTools/AudioOutput.h"
+#include "AudioTools/MusicalNotes.h"
 #include "AudioLibs/FFT/FFTWindows.h"
 
 /** 


### PR DESCRIPTION
Using Platformio with `esp32dev` or `arduino_nano_esp32` boards, building fails if the FFT library is included:

```
In file included from .pio/libdeps/arduino_nano_esp32/audio-tools/src/AudioLibs/AudioRealFFT.h:3,
                 from src/adc.cpp:7:
.pio/libdeps/arduino_nano_esp32/audio-tools/src/AudioLibs/AudioFFT.h:16:8: error: 'MusicalNotes' does not name a type
 static MusicalNotes AudioFFTNotes;
        ^~~~~~~~~~~~
.pio/libdeps/arduino_nano_esp32/audio-tools/src/AudioLibs/AudioFFT.h: In member function 'const char* audio_tools::AudioFFTResult::frequencyAsNote()':
.pio/libdeps/arduino_nano_esp32/audio-tools/src/AudioLibs/AudioFFT.h:31:16: error: 'AudioFFTNotes' was not declared in this scope
         return AudioFFTNotes.note(frequency);
                ^~~~~~~~~~~~~
.pio/libdeps/arduino_nano_esp32/audio-tools/src/AudioLibs/AudioFFT.h:31:16: note: suggested alternative: 'AudioFFTBase'
         return AudioFFTNotes.note(frequency);
                ^~~~~~~~~~~~~
                AudioFFTBase
.pio/libdeps/arduino_nano_esp32/audio-tools/src/AudioLibs/AudioFFT.h: In member function 'const char* audio_tools::AudioFFTResult::frequencyAsNote(float&)':
.pio/libdeps/arduino_nano_esp32/audio-tools/src/AudioLibs/AudioFFT.h:34:16: error: 'AudioFFTNotes' was not declared in this scope
         return AudioFFTNotes.note(frequency, diff);
                ^~~~~~~~~~~~~
.pio/libdeps/arduino_nano_esp32/audio-tools/src/AudioLibs/AudioFFT.h:34:16: note: suggested alternative: 'AudioFFTBase'
         return AudioFFTNotes.note(frequency, diff);
                ^~~~~~~~~~~~~
                AudioFFTBase
*** [.pio/build/arduino_nano_esp32/src/adc.cpp.o] Error 1
```

Adding an import for `MusicalNotes.h` makes the type known and allows the build to succeed.

(Might be a configuration issue on my side, but I'm not sure what it could be.)