### PR TITLE
fix: Add missing LockGuard include

### DIFF
--- a/src/AudioLibs/FFTDisplay.h
+++ b/src/AudioLibs/FFTDisplay.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "AudioLibs/AudioFFT.h"
+#include "Concurrency/LockGuard.h"
 
 namespace audio_tools {
 


### PR DESCRIPTION
Without the include, `platformio` fails to compile FFTDisplay.h:

```
In file included from src/adc.cpp:8:
.pio/libdeps/arduino_nano_esp32/audio-tools/src/AudioLibs/FFTDisplay.h:10:8: error: 'Mutex' does not name a type
   10 | static Mutex fft_mux;
      |        ^~~~~
.pio/libdeps/arduino_nano_esp32/audio-tools/src/AudioLibs/FFTDisplay.h: In member function 'void audio_tools::FFTDisplay::loadMangnitudes()':
.pio/libdeps/arduino_nano_esp32/audio-tools/src/AudioLibs/FFTDisplay.h:80:5: error: 'LockGuard' was not declared in this scope
   80 |     LockGuard guard(fft_mux);
      |     ^~~~~~~~~
```

Adding this include fixes the issue.