### PR TITLE
Fix race condition in esp now communication

### DIFF
--- a/src/Communication/ESPNowStream.h
+++ b/src/Communication/ESPNowStream.h
@@ -112,6 +112,7 @@ class ESPNowStream : public BaseStream {
         LOGE("Could not set mac address");
         return false;
       }
+      delay(500);  // On some boards calling macAddress to early leads to a race condition.
       // checking if address has been updated
       const char *addr = macAddress();
       if (strcmp(addr, cfg.mac_address) != 0) {


### PR DESCRIPTION
when calling mac address to fast after setting it

happened on ESP32-WROOM-32E with IDF version > 5

I noticed that the communication was working when logging was set to values >= Info, as soon as the logging level was decreased the mac address was not read back correctly.

```
with log level info
[I] ESPNowStream.h : 108 - setting mac C8:2E:18:5E:03:98
mac: C8:2E:18:5E:03:98
[I] ESPNowStream.h : 316 - esp_now_init:
[I] ESPNowStream.h : 162 - addPeer: b0:b2:1c:ff:a2:ab

with log level warning
[E] ESPNowStream.h : 118 - Wrong mac address: 00:00:00:00:00:00
[E] ESPNowStream.h : 157 - addPeer before begin
```

I tried to solve this by using polling but still the same.
So the only solution that worked for me was a small delay.