### PR TITLE
Fix issues in URLStream when compiling in ESP IDF

### DIFF
--- a/src/AudioHttp/HttpRequest.h
+++ b/src/AudioHttp/HttpRequest.h
@@ -288,7 +288,7 @@ class HttpRequest {
     if (isChunked()) {
       write(nullptr, 0);
     }
-    LOGI("Request written ... waiting for reply")
+    LOGI("Request written ... waiting for reply");
     // Commented out because this breaks the RP2040 W
     // client_ptr->flush();
     reply_header.read(*client_ptr);

--- a/src/AudioHttp/URLStream.h
+++ b/src/AudioHttp/URLStream.h
@@ -231,7 +231,7 @@ class URLStream : public AbstractURLStream {
     TRACED();
     uint32_t end = millis() + timeout;
     if (request.available() == 0) {
-      LOGI("Request written ... waiting for reply")
+      LOGI("Request written ... waiting for reply");
       while (request.available() == 0) {
         if (millis() > end) break;
         // stop waiting if we got an error

--- a/src/AudioI2S/I2SESP32V1.h
+++ b/src/AudioI2S/I2SESP32V1.h
@@ -313,6 +313,7 @@ class I2SDriverESP32V1 {
                 {
                     .clk = (gpio_num_t)cfg.pin_bck,
                     .dout = (gpio_num_t)txPin,
+                    .dout2 = (gpio_num_t)0,
                     .invert_flags =
                         {
                             .clk_inv = false,

--- a/src/AudioI2S/I2SESP32V1.h
+++ b/src/AudioI2S/I2SESP32V1.h
@@ -313,7 +313,6 @@ class I2SDriverESP32V1 {
                 {
                     .clk = (gpio_num_t)cfg.pin_bck,
                     .dout = (gpio_num_t)txPin,
-                    .dout2 = (gpio_num_t)0,
                     .invert_flags =
                         {
                             .clk_inv = false,

--- a/src/AudioTools/AudioRuntime.h
+++ b/src/AudioTools/AudioRuntime.h
@@ -8,11 +8,11 @@
 // delay and millis is needed by this framework
 #define DESKTOP_MILLIS_DEFINED
 
-inline void delay(uint32_t ms){ vTaskDelay(ms * 1000 / portTICK_PERIOD_MS);}
+inline void delay(uint32_t ms){ vTaskDelay(ms / portTICK_PERIOD_MS);}
 inline uint32_t millis() {return (xTaskGetTickCount() * portTICK_PERIOD_MS);}
 inline void delayMicroseconds(uint32_t ms) {esp_rom_delay_us(ms);}
 //inline uint64_t micros() { return xTaskGetTickCount();}
-extern uint64_t micros();
+// extern uint64_t micros();
 
 #endif
 


### PR DESCRIPTION
1. Fix incorrect delay implementation causing URLStream to take 50 seconds to start instead of 50ms
2. Add missing semi colon's
3. Remove duplicate micros declaration
4. Add missing .dout2 initializer to get rid of compile warning

Let me know if theres anything else you need me to provide.