### PR TITLE
feat(AudioSourceSD): pass an spi instance

### DIFF
--- a/src/AudioLibs/AudioSourceSD.h
+++ b/src/AudioLibs/AudioSourceSD.h
@@ -43,19 +43,19 @@ public:
   }
 
   // Pass your own spi instance, in case you need a dedicated one
-  AudioSourceSD(const char *startFilePath = "/", const char *ext = ".mp3", SPIClass &spiInstance = SPI, bool setupIndex=true) {
+  AudioSourceSD(const char *startFilePath = "/", const char *ext = ".mp3", int chipSelect = PIN_CS, SPIClass &spiInstance = SPI, bool setupIndex=true) {
     start_path = startFilePath;
     extension = ext;
     setup_index = setupIndex;
     spi = &spiInstance;
-    cs = spi->pinSS();
+    cs = chipSelect;
   }
 
   virtual void begin() override {
     TRACED();
     if (!is_sd_setup) {
       while (!SD.begin(cs, *spi)) {
-        LOGE("SD.begin cs=%d failed",cs);
+        LOGE("SD.begin cs=%d failed", cs);
         delay(1000);
       }
       is_sd_setup = true;

--- a/src/AudioLibs/AudioSourceSD.h
+++ b/src/AudioLibs/AudioSourceSD.h
@@ -38,13 +38,23 @@ public:
     start_path = startFilePath;
     extension = ext;
     setup_index = setupIndex;
+    spi = &SPI;
     cs = chipSelect;
+  }
+
+  // Pass your own spi instance, in case you need a dedicated one
+  AudioSourceSD(const char *startFilePath = "/", const char *ext = ".mp3", SPIClass &spiInstance = SPI, bool setupIndex=true) {
+    start_path = startFilePath;
+    extension = ext;
+    setup_index = setupIndex;
+    spi = &spiInstance;
+    cs = spi->pinSS();
   }
 
   virtual void begin() override {
     TRACED();
     if (!is_sd_setup) {
-      while (!SD.begin(cs)) {
+      while (!SD.begin(cs, *spi)) {
         LOGE("SD.begin cs=%d failed",cs);
         delay(1000);
       }
@@ -116,8 +126,7 @@ protected:
   bool setup_index = true;
   bool is_sd_setup = false;
   int cs;
-
-
+  SPIClass *spi = nullptr;
 };
 
 } // namespace audio_tools

--- a/src/AudioLibs/AudioSourceSD.h
+++ b/src/AudioLibs/AudioSourceSD.h
@@ -36,7 +36,7 @@ public:
   /// Default constructor
   AudioSourceSD(const char *startFilePath = "/", const char *ext = ".mp3", int chipSelect = PIN_CS, bool setupIndex=true) {
     start_path = startFilePath;
-    exension = ext;
+    extension = ext;
     setup_index = setupIndex;
     cs = chipSelect;
   }
@@ -50,7 +50,7 @@ public:
       }
       is_sd_setup = true;
     }
-    idx.begin(start_path, exension, file_name_pattern);
+    idx.begin(start_path, extension, file_name_pattern);
     idx_pos = 0;
   }
 
@@ -102,7 +102,7 @@ public:
   long size() { return idx.size();}
 
 protected:
-#if defined(USE_SD_NO_NS) 
+#if defined(USE_SD_NO_NS)
   SDDirect<SDClass, File> idx{SD};
 #else
   SDDirect<fs::SDFS,fs::File> idx{SD};
@@ -110,7 +110,7 @@ protected:
   File file;
   size_t idx_pos = 0;
   const char *file_name;
-  const char *exension = nullptr;
+  const char *extension = nullptr;
   const char *start_path = nullptr;
   const char *file_name_pattern = "*";
   bool setup_index = true;


### PR DESCRIPTION
Related discussion: https://github.com/pschatzmann/arduino-audio-tools/discussions/1716

I think this is ok ; at least it compiles. I've still trouble trying to make the audio stream going to my speaker so I cannot guarantee it works.

Currently the setup I have this is one:


```ino
#include "AudioTools.h"
#include "AudioLibs/A2DPStream.h"
#include "AudioLibs/AudioSourceSD.h"
#include "AudioCodecs/CodecMP3Helix.h"

// this custom setup to avoid taking VSPI + not cluttering D12
#define HSPI_SCLK 26
#define HSPI_MISO 33
#define HSPI_MOSI 25
#define HSPI_SS   27

const char *startFilePath="/";
const char *ext="mp3";

SPIClass hspi(HSPI);
AudioSourceSD source(startFilePath, ext, HSPI_SS, hspi);

A2DPStream out;
MP3DecoderHelix decoder;
AudioPlayer player(source, out, decoder);

void setup() {
  Serial.begin(115200);
  AudioLogger::instance().begin(Serial, AudioLogger::Debug);

  hspi.begin(HSPI_SCLK, HSPI_MISO, HSPI_MOSI, HSPI_SS);

  // setup output
  auto cfg = out.defaultConfig(TX_MODE);

  // my speaker. tested working with A2DPAudioSource + SineWave example
  cfg.name = "Bose Color II SoundLink";
  cfg.auto_reconnect = false;
  out.begin(cfg);

  // setup player
  player.begin();
}

void loop() {
  player.copy();
}
```