### PR TITLE
StreamCopy.h heap bug

### DIFF
--- a/src/AudioTools/CoreAudio/StreamCopy.h
+++ b/src/AudioTools/CoreAudio/StreamCopy.h
@@ -55,7 +55,10 @@ class StreamCopyT {
 
         /// Ends the processing
         void end() {
-            this->from = nullptr;
+            if (this->from != nullptr) {
+                delete this->from;
+                this->from = nullptr;
+            }
             this->to = nullptr;
         }
 


### PR DESCRIPTION
StreamCopy->from does not free when call StreamCopy->end. That will result in heap leak.