### PR TITLE
Non blocking A2DPStream begin()

### DIFF
--- a/src/AudioTools/AudioLibs/A2DPStream.h
+++ b/src/AudioTools/AudioLibs/A2DPStream.h
@@ -54,7 +54,7 @@ class A2DPConfig {
         int delay_ms = 1;
         /// when a2dp source is active but has no data we generate silence data
         bool silence_on_nodata = false;
-        /// write timeout in ms: -1 is wait_connection write
+        /// write timeout in ms: -1 is blocking write
         int tx_write_timeout_ms = -1; // no timeout
 };
 
@@ -241,7 +241,7 @@ class A2DPStream : public AudioStream, public VolumeSupport {
                     is_a2dp_active = true;
                 }
 
-                // wait_connection write: if buffer is full we wait
+                // blocking write: if buffer is full we wait
                 int timeout = config.tx_write_timeout_ms;
                 int wait_time = 5;
                 size_t free = a2dp_buffer.availableForWrite();

--- a/src/AudioTools/AudioLibs/A2DPStream.h
+++ b/src/AudioTools/AudioLibs/A2DPStream.h
@@ -123,15 +123,15 @@ class A2DPStream : public AudioStream, public VolumeSupport {
         }
 
         /// Starts the processing
-        bool begin(RxTxMode mode, const char* name, bool wait_connection=true){
+        bool begin(RxTxMode mode, const char* name, bool wait_for_connection=true){
             A2DPConfig cfg;
             cfg.mode = mode;
             cfg.name = name;
-            return begin(cfg, wait_connection);
+            return begin(cfg, wait_for_connection);
         }
 
         /// Starts the processing
-        bool begin(A2DPConfig cfg, bool wait_connection=true){
+        bool begin(A2DPConfig cfg, bool wait_for_connection=true){
             this->config = cfg;
             bool result = false;
             LOGI("Connecting to %s",cfg.name);
@@ -159,7 +159,7 @@ class A2DPStream : public AudioStream, public VolumeSupport {
                     }
                     a2dp_source->set_on_connection_state_changed(a2dp_state_callback, this);
                     a2dp_source->start_raw((char*)cfg.name, a2dp_stream_source_sound_data);
-                    if (wait_connection){
+                    if (wait_for_connection){
                         while(!a2dp_source->is_connected()){
                             LOGD("waiting for connection");
                             delay(1000);
@@ -174,7 +174,6 @@ class A2DPStream : public AudioStream, public VolumeSupport {
                     result = true;
                     break;
 
-
                 case RX_MODE:
                     LOGI("Starting a2dp_sink...");
                     sink(); // allocate object
@@ -184,7 +183,7 @@ class A2DPStream : public AudioStream, public VolumeSupport {
                     a2dp_sink->set_on_connection_state_changed(a2dp_state_callback, this);
                     a2dp_sink->set_sample_rate_callback(sample_rate_callback);
                     a2dp_sink->start((char*)cfg.name);
-                    if (wait_connection){
+                    if (wait_for_connection){
                         while(!a2dp_sink->is_connected()){
                             LOGD("waiting for connection");
                             delay(1000);

--- a/src/AudioTools/AudioLibs/A2DPStream.h
+++ b/src/AudioTools/AudioLibs/A2DPStream.h
@@ -159,20 +159,20 @@ class A2DPStream : public AudioStream, public VolumeSupport {
                     }
                     a2dp_source->set_on_connection_state_changed(a2dp_state_callback, this);
                     a2dp_source->start_raw((char*)cfg.name, a2dp_stream_source_sound_data);
-					if (wait_connection){
-						while(!a2dp_source->is_connected()){
-							LOGD("waiting for connection");
-							delay(1000);
-						}
-						LOGI("a2dp_source is connected...");
-						notify_base_Info(44100);
-						//is_a2dp_active = true;
-					}
-					else{
-						LOGI("a2dp_source started without connecting");
-					}
-					result = true;
-					break;
+                    if (wait_connection){
+                        while(!a2dp_source->is_connected()){
+                            LOGD("waiting for connection");
+                            delay(1000);
+                        }
+                        LOGI("a2dp_source is connected...");
+                        notify_base_Info(44100);
+                        //is_a2dp_active = true;
+                    }
+                    else{
+                        LOGI("a2dp_source started without connecting");
+                    }
+                    result = true;
+                    break;
 
 
                 case RX_MODE:
@@ -184,19 +184,19 @@ class A2DPStream : public AudioStream, public VolumeSupport {
                     a2dp_sink->set_on_connection_state_changed(a2dp_state_callback, this);
                     a2dp_sink->set_sample_rate_callback(sample_rate_callback);
                     a2dp_sink->start((char*)cfg.name);
-					if (wait_connection){
-						while(!a2dp_sink->is_connected()){
-							LOGD("waiting for connection");
-							delay(1000);
-						}
-						LOGI("a2dp_sink is connected...");
-					}
-					else{
-						LOGI("a2dp_sink started without connection");
-					}
-					is_a2dp_active = true;
-					result = true;
-					break;
+                    if (wait_connection){
+                        while(!a2dp_sink->is_connected()){
+                            LOGD("waiting for connection");
+                            delay(1000);
+                        }
+                        LOGI("a2dp_sink is connected...");
+                    }
+                    else{
+                        LOGI("a2dp_sink started without connection");
+                    }
+                    is_a2dp_active = true;
+                    result = true;
+                    break;
                 default:
                     LOGE("Undefined mode: %d", cfg.mode);
                     break;


### PR DESCRIPTION
Unlike BluetoothA2DPSink/Source's implementation, audio-tools one waits until a connection is made to unblock the execution. This commit solves that by making that wait optional and with backwards compatibility.
I have tried this in RX mode, but I imagine that in TX mode it should work as well.