### PR TITLE
Fix typo in CodecHelix.h

### DIFF
--- a/src/AudioTools/AudioCodecs/CodecHelix.h
+++ b/src/AudioTools/AudioCodecs/CodecHelix.h
@@ -22,9 +22,9 @@ class DecoderHelix : public MultiDecoder {
  public:
   DecoderHelix() {
     // register supported codecs with their mime type
-    multi.addDecoder(mp3, "audio/mpeg");
-    multi.addDecoder(aac, "audio/aac");
-    multi.addDecoder(wav, "audio/vnd.wave");
+    addDecoder(mp3, "audio/mpeg");
+    addDecoder(aac, "audio/aac");
+    addDecoder(wav, "audio/vnd.wave");
   }
 
  protected:


### PR DESCRIPTION
Since CodecHelix is a subclass of MultiDecoder, there is no `multi` field in it, so build fails.