### PR TITLE
Allow setting timeout on ICYStream

### DIFF
--- a/src/AudioTools/CoreAudio/AudioHttp/ICYStream.h
+++ b/src/AudioTools/CoreAudio/AudioHttp/ICYStream.h
@@ -147,6 +147,8 @@ class ICYStream : public AbstractURLStream {
   /// of performance! - By default this is deactivated. ESP32 Only!
   void setPowerSave(bool active) { url.setPowerSave(active);}
 
+  /// Sets the timeout of the URL stream's client
+  void setTimeout(int ms) { url.setTimeout(ms); }
  protected:
   URLStream url;
   MetaDataICY icy;  // icy state machine


### PR DESCRIPTION
This is sometimes necessary for servers that are far away and slow to respond. Using the `.request().setTimeout()` method is not always reliable because it needs to be done on a per-request basis, and the code inside URLStream overrides it with URLStream's clientTimeout when starting the request.