### PR TITLE
Prevent double-free of opus decoder

### DIFF
--- a/src/AudioTools/AudioCodecs/CodecOpus.h
+++ b/src/AudioTools/AudioCodecs/CodecOpus.h
@@ -176,10 +176,7 @@ class OpusAudioDecoder : public AudioDecoder {
 
   void end() override {
     TRACED();
-    if (dec) {
-      opus_decoder_destroy(dec);
-      dec = nullptr;
-    }
+    dec = nullptr;
     outbuf.resize(0);
     decbuf.resize(0);
     active = false;


### PR DESCRIPTION
Fixes:
```
Backtrace: 0x4008335d:0x3ffb1f30 0x40089435:0x3ffb1f50 0x4008f622:0x3ffb1f70 0x4008e32b:0x3ffb20a0 0x4008369f:0x3ffb20c0 0x4008f655:0x3ffb20e0 0x400e1645:0x3ffb2100 0x400db9e2:0x3ffb2120 0x400d48dd:0x3ffb2150 0x400d9f58:0x3ffb2180 0x400dfbba:0x3ffb21a0 0x400dfe1a:0x3ffb21c0 0x400dfff6:0x3ffb2200 0x400e0045:0x3ffb2230 0x400e0085:0x3ffb2250 0x401076c0:0x3ffb2270 0x4008a106:0x3ffb2290
  #0  0x4008335d in panic_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/panic.c:463
  #1  0x40089435 in esp_system_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/port/esp_system_chip.c:92
  #2  0x4008f622 in __assert_func at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/newlib/assert.c:80
  #3  0x4008e32b in multi_heap_free at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/multi_heap_poisoning.c:279 (discriminator 1)
  #4  0x4008369f in heap_caps_free at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/heap_caps_base.c:70
  #5  0x4008f655 in free at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/newlib/heap.c:39
  #6  0x400e1645 in opus_free at .pio/libdeps/esp32dev/arduino-libopus/src/../src/opus-1.3.1/celt/os_support.h:66
      (inlined by) opus_decoder_destroy at .pio/libdeps/esp32dev/arduino-libopus/src/opus-1.3.1/src/opus_decoder.c:968
  #7  0x400db9e2 in audio_tools::OpusAudioDecoder::end() at .pio/libdeps/esp32dev/arduino-audio-tools/src/AudioTools/AudioCodecs/CodecOpus.h:180
  #8  0x400d48dd in audio_tools::EncodedAudioOutput::end() at .pio/libdeps/esp32dev/arduino-audio-tools/src/AudioTools/AudioCodecs/AudioEncoded.h:171
  #9  0x400d9f58 in audio_tools::EncodedAudioStream::end() at .pio/libdeps/esp32dev/arduino-audio-tools/src/AudioTools/AudioCodecs/AudioEncoded.h:356
      (inlined by) endI2STx() at kv4p_ht_esp32_wroom_32/txAudio.h:56
 ```

The memory is released by `decbuf.resize(0);`.