### PR TITLE
add playFile() blocking method for audio playback

### DIFF
--- a/src/AudioTools/CoreAudio/AudioPlayer.h
+++ b/src/AudioTools/CoreAudio/AudioPlayer.h
@@ -252,6 +252,32 @@ public:
     setActive(true);
   }
 
+  /// plays a complete audio file from start to finish (blocking call)
+  /// @param filePath path to the audio file to play
+  /// @return true if file was found and played successfully, false otherwise
+  bool playFile(const char *filePath) {
+    TRACED();
+    if (!setPath(filePath)) {
+      LOGW("Could not open file: %s", filePath);
+      return false;
+    }
+    
+    LOGI("Playing %s", filePath);
+    play();
+    
+    while (isActive()) {
+      size_t bytes_copied = copy();
+      // if no bytes were copied, the file may have ended
+      if (bytes_copied == 0) {
+        stop();
+        break;
+      }
+    }
+    
+    LOGI("%s has finished playing", filePath);
+    return true;
+  }
+
   /// halts the playing: same as setActive(false)
   void stop() {
     TRACED();


### PR DESCRIPTION
### summary:
adds a new `playFile(const char *filePath)` method to the `AudioPlayer` class that provides a simple blocking way to play a complete audio file from start to finish.

### changes
- new public method: `bool playFile(const char *filePath)` in the public section of `AudioPlayer` class
- functionality:
  - sets the audio file path using existing `setPath()` method
  - starts playback with `play()`
  - blocks execution until the entire file finishes playing
  - stops when no more audio data is available
  - returns `true` on success, `false` if file cannot be opened

### use case:
i used this library for an ESP32 project at school and needed a blocking method to do nothing BUT play a specific audio file before continuing the program, so i made my own and thought other people might need it!

### example usage:
```cpp
AudioPlayer player(source, output, decoder);

...

setup() {
  player.begin();
}

...

loop() {
  // play a complete file (blocking)
  if (player.playFile("/foo.mp3")) {
    // file plays successfully
  } else {
    // file not found or other error occurred
  }

  doSomethingElse();
}
```

this addition shouldn't affect any existing functionality!