### PR TITLE
Avoid task WDT invoked when URLStreamBufferedESP32 stream is temporarily stopped

### DIFF
--- a/src/AudioTools/Communication/HTTP/URLStreamBufferedT.h
+++ b/src/AudioTools/Communication/HTTP/URLStreamBufferedT.h
@@ -124,6 +124,8 @@ class BufferedTaskStream : public AudioStream {
     if (*(this->p_stream) && available_to_write > 0) {
       size_t to_read = min(available_to_write, (size_t)512);
       uint8_t buffer[to_read];
+      while (this->p_stream->available() == 0)
+        delay(3); // to avoid task WDT invoked while blocking read
       size_t avail_read = this->p_stream->readBytes((uint8_t *)buffer, to_read);
       size_t written = this->buffers.writeArray(buffer, avail_read);
 

--- a/src/AudioTools/Concurrency/RTOS/SynchronizedNBufferRTOS.h
+++ b/src/AudioTools/Concurrency/RTOS/SynchronizedNBufferRTOS.h
@@ -2,6 +2,8 @@
 #include "AudioToolsConfig.h"
 #include "QueueRTOS.h"
 
+#define DEFAULT_BUFFER_WAIT 1000
+
 namespace audio_tools {
 
 /**
@@ -14,7 +16,7 @@ namespace audio_tools {
 template <typename T> 
 class SynchronizedNBufferRTOST : public NBuffer<T> {
 public:
-  SynchronizedNBufferRTOST(int bufferSize, int bufferCount, int writeMaxWait=portMAX_DELAY, int readMaxWait=portMAX_DELAY) {
+  SynchronizedNBufferRTOST(int bufferSize, int bufferCount, int writeMaxWait=DEFAULT_BUFFER_WAIT, int readMaxWait=DEFAULT_BUFFER_WAIT) {
     TRACED();
     read_max_wait = readMaxWait;
     write_max_wait = writeMaxWait;
@@ -77,8 +79,8 @@ public:
   }
 
 protected:
-  QueueRTOS<BaseBuffer<T>*> available_buffers{0,portMAX_DELAY,0};
-  QueueRTOS<BaseBuffer<T>*> filled_buffers{0,portMAX_DELAY,0};
+  QueueRTOS<BaseBuffer<T>*> available_buffers{0,DEFAULT_BUFFER_WAIT,0};
+  QueueRTOS<BaseBuffer<T>*> filled_buffers{0,DEFAULT_BUFFER_WAIT,0};
   size_t max_size;
   size_t read_max_wait, write_max_wait;
   int buffer_size = 0, buffer_count = 0;


### PR DESCRIPTION
When `URLStreamBuffered` is used on ESP32 and the stream is temporarily stopped for several seconds, the task watchdog timer is invoked within the `BufferedTaskStream` task and ESP32 is reset, because the task is blocked while `readBytes()` from the stream.
( This can be seen in the stream like [jazz cafe](http://radio.wanderingsheep.net:8000/jazzcafe?_ic2=0), that has a few seconds gaps between tunes. )

This patch avoids the WDT by calling `dalay()` if there is no readable bytes.


In addition, if the stream is stopped, the sink like `AudioPlayer::copy()` from the `URLStreamBuffered` is also blocked and makes it difficult to handle timeouts (e.g. switching to the next source). This changes the default timeout of `SynchronizedNBufferRTOST` to 1 second, so that the copier can return with `0` copied byte after the timeout.