### PR TITLE
Replace heuristic printable checker with simple UTF-8/ASCII validator

### DIFF
--- a/src/AudioTools/Communication/HTTP/HttpLineReader.h
+++ b/src/AudioTools/Communication/HTTP/HttpLineReader.h
@@ -72,67 +72,7 @@ class HttpLineReader {
     }
     str[result - 1] = 0;
     if (is_buffer_overflow) {
-      // SAFETY FIX: Don't print potentially corrupted binary data with %s
-      // Binary garbage can contain terminal escape codes or invalid UTF-8 that crashes Serial.printf()
-      //
-      // This fix prevents ESP32 hard resets when HTTP servers send malformed headers
-      // Real-world trigger: http://fast.citrus3.com:2020/stream/wtmj-radio
-      //
-      // Strategy:
-      // 1. Sanitize the actual buffer (prevents parser poisoning downstream)
-      // 2. Count printable vs binary content
-      // 3. Use hex dump for binary garbage (safer than string masking)
-      // 4. Limit output to 256 bytes (prevents log spam)
-
-      int printable = 0;
-      int non_printable = 0;
-      int actual_len = 0;
-
-      // First pass: count and find actual length
-      for (int i = 0; i < len && str[i] != 0; i++) {
-        actual_len = i + 1;
-        if (str[i] >= 32 && str[i] <= 126) {
-          printable++;
-        } else if (str[i] != '\r' && str[i] != '\n' && str[i] != '\t') {
-          non_printable++;
-          // CRITICAL: Sanitize the actual buffer to prevent parser poisoning
-          // Replace binary garbage with space to avoid confusing HTTP header parser
-          str[i] = ' ';
-        }
-      }
-
-      // Limit logging output to 256 bytes to prevent excessive serial spam
-      int log_len = (actual_len > 256) ? 256 : actual_len;
-
-      // If mostly binary garbage (>50% non-printable), use hex dump for safety
-      if (non_printable > printable) {
-        LOGE("Line cut off: [%d bytes, %d binary chars - showing hex dump of first %d bytes]",
-             actual_len, non_printable, (log_len > 32 ? 32 : log_len));
-
-        // Hex dump (safer than string output - never misinterpreted)
-        // Show first 32 bytes maximum
-        int hex_len = (log_len > 32) ? 32 : log_len;
-        for (int i = 0; i < hex_len; i += 16) {
-          char hex_line[64];
-          int line_len = (hex_len - i > 16) ? 16 : (hex_len - i);
-          int pos = 0;
-          for (int j = 0; j < line_len; j++) {
-            pos += snprintf(hex_line + pos, sizeof(hex_line) - pos, "%02X ", (uint8_t)str[i + j]);
-          }
-          LOGE("  %04X: %s", i, hex_line);
-        }
-      } else {
-        // Mostly printable - safe to log as string (already sanitized in-place above)
-        // Truncate to 256 bytes for logging
-        if (log_len < actual_len) {
-          char saved = str[log_len];
-          str[log_len] = 0;
-          LOGE("Line cut off: %s... [%d more bytes]", str, actual_len - log_len);
-          str[log_len] = saved;
-        } else {
-          LOGE("Line cut off: %s", str);
-        }
-      }
+      LOGE("HttpLineReader %s", "readlnInternal->cut off too long line");
     }
 
     return result;


### PR DESCRIPTION
#2236 tried to introduce some code to avoid breaking the Serial console by malformed binary garbage, but the changes were redundant and the garbage was still printed to the console.

- It replaced the heuristic that checked only the first 12 bytes with a full-string check, but this is as costly as a full ASCII /  UTF-8 validation.
- It added another heuristic specifically for LOGE(), but to stop logging the buffer content is sufficient.

This PR replaces heuristics with full ASCII/UTF-8 string validation.
- By default, only ASCII printable characters are allowed.
- Defining `#define AUDIOTOOLS_METADATA_ICY_ASCII_ONLY false` allows valid UTF-8 strings.
