### PR TITLE
Recognize end of string in isPrintable

### DIFF
--- a/src/AudioTools/CoreAudio/AudioMetaData/MetaDataICY.h
+++ b/src/AudioTools/CoreAudio/AudioMetaData/MetaDataICY.h
@@ -173,6 +173,7 @@ class MetaDataICY : public AbstractMetaData {
     int remain = 0;
     for (int j = 0; j < l; j++) {
       uint8_t ch = str[j];
+      if (!ch) break;
       if (remain) {
         if (ch < 0x80 || ch > 0xbf) return false;
         remain--;


### PR DESCRIPTION
It seems that last block of metadata may contain `\0` at the end of the string.
This makes isPrintable() to stop the check loop on the `\0` so that decoder can receive the last metadata.