### PR TITLE
fixed typo: a missing o in desktop example

### DIFF
--- a/examples/examples-desktop/generator/README.md
+++ b/examples/examples-desktop/generator/README.md
@@ -3,7 +3,7 @@
 We provide some generic output which will also work on Linux, Windows and OS/X
 The cmake is downloading all dependencies and builds an executable from the sketch.
 
-You just need to provide an Arduino Sketch as cpp file. In our example we use an example setup that can be compiled both in Arduin and with cmake: 
+You just need to provide an Arduino Sketch as cpp file. In our example we use an example setup that can be compiled both in Arduino and with cmake: 
 
 - the sketch is provided as ino file
 - the cpp file is including the Arduino.h and the ino file


### PR DESCRIPTION
fixed typo: a missing o in desktop example