### PR TITLE
Add a couple of small updates to the espnow communication component

### DIFF
--- a/src/AudioTools/Communication/ESPNowStream.h
+++ b/src/AudioTools/Communication/ESPNowStream.h
@@ -152,8 +152,13 @@ class ESPNowStream : public BaseStream {
         while (WiFi.status() != WL_CONNECTED) {
           Serial.print('.');
           delay(1000);
-      }else{
+      } else if (cfg.wifi_mode==WIFI_STA) {
         while (!WiFi.STA.started()) {
+          Serial.print('.');
+          delay(1000);
+        }
+      } else {
+        while (!WiFi.AP.started()) {
           Serial.print('.');
           delay(1000);
         }


### PR DESCRIPTION
This PR adds 3 small updates to the espnow component:

1. add's the option to set long range wifi option.
2. allow to set the data Rate for esp-IDF >= v5.0.0
3. Start WiFi also when the SSID and password is not set.