### PR TITLE
codecs: fix Ogg Opus container generation

### DIFF
--- a/src/AudioTools/AudioCodecs/CodecOpus.h
+++ b/src/AudioTools/AudioCodecs/CodecOpus.h
@@ -282,7 +282,8 @@ class OpusAudioEncoder : public AudioEncoder {
   /// starts the processing using the actual OpusAudioInfo
   bool begin() override {
     int err;
-    int size = getFrameSizeSamples(cfg.sample_rate) * 2;
+    int size = getFrameSizeSamples(cfg.sample_rate) * cfg.channels *
+               sizeof(int16_t);
     frame.resize(size);
     assert(frame.data() != nullptr);
     enc = opus_encoder_create(cfg.sample_rate, cfg.channels, cfg.application,
@@ -308,10 +309,16 @@ class OpusAudioEncoder : public AudioEncoder {
 
   /// stops the processing
   void end() override {
-    // flush buffered data
-    encodeFrame();
+    // Flush a partial frame only when data is pending; the remainder is
+    // padded with silence and must be trimmed by the container metadata.
+    if (frame_pos > 0) {
+      memset(frame.data() + frame_pos, 0, frame.size() - frame_pos);
+      encodeFrame();
+      frame_pos = 0;
+    }
     // release memory
     opus_encoder_destroy(enc);
+    enc = nullptr;
     is_open = false;
   }
 
@@ -330,6 +337,23 @@ class OpusAudioEncoder : public AudioEncoder {
   operator bool() override { return is_open; }
 
   bool isOpen() { return is_open; }
+
+  int lookaheadSamples() {
+    if (enc == nullptr) return 0;
+    opus_int32 samples = 0;
+    if (opus_encoder_ctl(enc, OPUS_GET_LOOKAHEAD(&samples)) != OPUS_OK) {
+      return 0;
+    }
+    return samples > 0 ? samples : 0;
+  }
+
+  int frameSizeSamples() { return getFrameSizeSamples(cfg.sample_rate); }
+
+  int pendingSamples() {
+    int bytesPerSample = cfg.channels * (int)sizeof(int16_t);
+    if (bytesPerSample <= 0) return 0;
+    return frame_pos / bytesPerSample;
+  }
 
  protected:
   Print *p_print = nullptr;

--- a/src/AudioTools/AudioCodecs/CodecOpusOgg.h
+++ b/src/AudioTools/AudioCodecs/CodecOpusOgg.h
@@ -89,9 +89,9 @@ class OpusOggWriter : public OggContainerOutput {
   OpusOggCommentHeader comment;
   ogg_packet oh1;
   Vector<uint8_t> pendingPacket{0};
-  uint32_t totalGranulepos = 0;
-  uint32_t samplesPerPacket = 960;
-  uint32_t finalPacketSamples = 0;
+  ogg_int64_t totalGranulepos = 0;
+  ogg_int64_t samplesPerPacket = 960;
+  ogg_int64_t finalPacketSamples = 0;
   bool hasPendingPacket = false;
 
   bool writeHeader() override {
@@ -129,7 +129,7 @@ class OpusOggWriter : public OggContainerOutput {
     return result;
   }
 
-  bool emitBufferedPacket(uint32_t granulePosition, bool endOfStream) {
+  bool emitBufferedPacket(ogg_int64_t granulePosition, bool endOfStream) {
     if (!hasPendingPacket) return true;
 
     op.packet = pendingPacket.data();
@@ -157,12 +157,12 @@ class OpusOggWriter : public OggContainerOutput {
   }
 
   void setFrameDurationUs(uint32_t frameDurationUs) {
-    uint32_t opusSamples = (uint32_t)(((uint64_t)frameDurationUs * 48000U) /
-                                      1000000U);
+    ogg_int64_t opusSamples =
+        (ogg_int64_t)(((uint64_t)frameDurationUs * 48000ULL) / 1000000ULL);
     samplesPerPacket = opusSamples > 0 ? opusSamples : 960;
   }
 
-  void setFinalPacketSamples(uint32_t samples) {
+  void setFinalPacketSamples(ogg_int64_t samples) {
     finalPacketSamples = samples;
   }
 
@@ -188,7 +188,7 @@ class OpusOggWriter : public OggContainerOutput {
     TRACED();
 
     if (hasPendingPacket) {
-      uint32_t keptSamples =
+      ogg_int64_t keptSamples =
           finalPacketSamples > 0 ? finalPacketSamples : samplesPerPacket;
       if (keptSamples > samplesPerPacket) {
         keptSamples = samplesPerPacket;
@@ -298,9 +298,9 @@ class OpusOggEncoder : public OggContainerEncoder {
       finalSamples = enc.frameSizeSamples();
     }
 
-    uint32_t finalGranuleSamples =
-        (uint32_t)(((uint64_t)finalSamples * 48000U) /
-                   (uint32_t)enc.config().sample_rate);
+    ogg_int64_t finalGranuleSamples =
+        (ogg_int64_t)(((uint64_t)finalSamples * 48000ULL) /
+                      (uint32_t)enc.config().sample_rate);
     ogg_writer.setFinalPacketSamples(finalGranuleSamples);
 
     OggContainerEncoder::end();

--- a/src/AudioTools/AudioCodecs/CodecOpusOgg.h
+++ b/src/AudioTools/AudioCodecs/CodecOpusOgg.h
@@ -88,10 +88,18 @@ class OpusOggWriter : public OggContainerOutput {
   OpusOggHeader header;
   OpusOggCommentHeader comment;
   ogg_packet oh1;
+  Vector<uint8_t> pendingPacket{0};
+  uint32_t totalGranulepos = 0;
+  uint32_t samplesPerPacket = 960;
+  uint32_t finalPacketSamples = 0;
+  bool hasPendingPacket = false;
 
   bool writeHeader() override {
     LOGI("writeHeader");
     bool result = true;
+    totalGranulepos = 0;
+    finalPacketSamples = 0;
+    hasPendingPacket = false;
     header.sampleRate = cfg.sample_rate;
     header.channelCount = cfg.channels;
     // write header
@@ -111,7 +119,7 @@ class OpusOggWriter : public OggContainerOutput {
     oh1.bytes = sizeof(comment);
     oh1.granulepos = 0;
     oh1.packetno = packetno++;
-    oh1.b_o_s = true;
+    oh1.b_o_s = false;
     oh1.e_o_s = false;
     if (!writePacket(oh1, OGGZ_FLUSH_AFTER)) {
       result = false;
@@ -119,6 +127,79 @@ class OpusOggWriter : public OggContainerOutput {
     }
     TRACED();
     return result;
+  }
+
+  bool emitBufferedPacket(uint32_t granulePosition, bool endOfStream) {
+    if (!hasPendingPacket) return true;
+
+    op.packet = pendingPacket.data();
+    op.bytes = pendingPacket.size();
+    op.granulepos = granulePosition;
+    op.b_o_s = false;
+    op.e_o_s = endOfStream;
+    op.packetno = packetno++;
+    is_audio = true;
+    if (!writePacket(op, OGGZ_FLUSH_AFTER)) {
+      return false;
+    }
+
+    while ((oggz_write(p_oggz, op.bytes)) > 0)
+      ;
+
+    hasPendingPacket = false;
+    pendingPacket.resize(0);
+    return true;
+  }
+
+ public:
+  void setPreSkipSamples(uint16_t preSkipSamples) {
+    header.preSkip = preSkipSamples;
+  }
+
+  void setFrameDurationUs(uint32_t frameDurationUs) {
+    uint32_t opusSamples = (uint32_t)(((uint64_t)frameDurationUs * 48000U) /
+                                      1000000U);
+    samplesPerPacket = opusSamples > 0 ? opusSamples : 960;
+  }
+
+  void setFinalPacketSamples(uint32_t samples) {
+    finalPacketSamples = samples;
+  }
+
+  size_t write(const uint8_t *data, size_t len) override {
+    if (data == nullptr) return 0;
+    LOGD("OpusOggWriter::write: %d", (int)len);
+
+    if (hasPendingPacket) {
+      totalGranulepos += samplesPerPacket;
+      if (!emitBufferedPacket(totalGranulepos, false)) {
+        return 0;
+      }
+    }
+
+    pendingPacket.resize(len);
+    memcpy(pendingPacket.data(), data, len);
+    hasPendingPacket = true;
+
+    return len;
+  }
+
+  void end() override {
+    TRACED();
+
+    if (hasPendingPacket) {
+      uint32_t keptSamples =
+          finalPacketSamples > 0 ? finalPacketSamples : samplesPerPacket;
+      if (keptSamples > samplesPerPacket) {
+        keptSamples = samplesPerPacket;
+      }
+      totalGranulepos += keptSamples;
+      emitBufferedPacket(totalGranulepos, true);
+    }
+
+    is_open = false;
+    oggz_close(p_oggz);
+    p_oggz = nullptr;
   }
 };
 
@@ -148,7 +229,7 @@ class OpusOggEncoder : public OggContainerEncoder {
   uint32_t frameDurationUs() override {
     // Get frame duration from encoder settings
     int frameDurationMs = config().frame_sizes_ms_x2;
-    uint32_t frameDurationUs = 20000;
+    uint32_t frameDurationUs = 10000;
     switch (frameDurationMs) {
       case OPUS_FRAMESIZE_2_5_MS:
         frameDurationUs = 2500;
@@ -162,8 +243,67 @@ class OpusOggEncoder : public OggContainerEncoder {
       case OPUS_FRAMESIZE_20_MS:
         frameDurationUs = 20000;
         break;
+      case OPUS_FRAMESIZE_40_MS:
+        frameDurationUs = 40000;
+        break;
+      case OPUS_FRAMESIZE_60_MS:
+        frameDurationUs = 60000;
+        break;
+      case OPUS_FRAMESIZE_80_MS:
+        frameDurationUs = 80000;
+        break;
+      case OPUS_FRAMESIZE_100_MS:
+        frameDurationUs = 100000;
+        break;
+      case OPUS_FRAMESIZE_120_MS:
+        frameDurationUs = 120000;
+        break;
     }
     return frameDurationUs;
+  }
+
+  bool begin(AudioInfo from) override {
+    setAudioInfo(from);
+    return begin();
+  }
+
+  bool begin() override {
+    if (p_codec == nullptr) return false;
+
+    ogg_writer.setFrameDurationUs(frameDurationUs());
+    p_codec->setOutput(*p_ogg);
+    if (!p_codec->begin(p_ogg->audioInfo())) {
+      return false;
+    }
+
+    int lookaheadSamples = enc.lookaheadSamples();
+    if (lookaheadSamples > 0) {
+      uint32_t preSkipSamples =
+          (uint32_t)(((uint64_t)lookaheadSamples * 48000U) /
+                     (uint32_t)enc.config().sample_rate);
+      ogg_writer.setPreSkipSamples((uint16_t)preSkipSamples);
+    }
+
+    if (!p_ogg->begin()) {
+      p_codec->end();
+      return false;
+    }
+
+    return true;
+  }
+
+  void end() override {
+    int finalSamples = enc.pendingSamples();
+    if (finalSamples <= 0) {
+      finalSamples = enc.frameSizeSamples();
+    }
+
+    uint32_t finalGranuleSamples =
+        (uint32_t)(((uint64_t)finalSamples * 48000U) /
+                   (uint32_t)enc.config().sample_rate);
+    ogg_writer.setFinalPacketSamples(finalGranuleSamples);
+
+    OggContainerEncoder::end();
   }
 
  protected:


### PR DESCRIPTION
## Summary

Fix several Ogg Opus container-generation issues in the `OpusOggEncoder` path that can cause broken playback metadata and poor interoperability across media players.

## What changed

- fix the `OpusTags` comment header so it is no longer incorrectly marked BOS
- stop deriving Opus granule positions from compressed packet byte length
- align default Opus frame-duration handling with the encoder's actual default packet size
- write `OpusHead.preSkip` from the encoder's real lookahead instead of a hardcoded value
- end the stream on the last real Opus packet instead of emitting an invalid zero-byte EOS audio packet
- apply proper final-packet end trimming through the final granule position
- only flush a partial encoder frame when PCM is actually pending
- size the encoder PCM frame buffer using `frame_size * channels * sizeof(int16_t)`

## Why

The previous implementation could produce `.ogg` files that:

- played in some players but not others
- reported no duration or incorrect duration
- could not be sought correctly
- contained incorrect beginning/end trimming metadata