### PR TITLE
fix: use_freertos define typo

### DIFF
--- a/src/AudioTools/Communication/USB/USBAudioStream.h
+++ b/src/AudioTools/Communication/USB/USBAudioStream.h
@@ -6,7 +6,7 @@
 #if defined(USE_TINYUSB) 
 #  include "USBAudioDeviceBase.h"
 #  include "USBAudioDeviceTinyUSB.h"
-#  if defined(USE_FREETROS)
+#  if defined(USE_FREERTOS)
 #    include "AudioTools/Concurrency.h"
 #    include "USBAudioDeviceTinyUSBFreeRTOS.h"
      namespace audio_tools { using USBAudioStream = USBAudioDeviceTinyUSBFreeRTOS; }

--- a/src/AudioTools/Concurrency/RP2040.h
+++ b/src/AudioTools/Concurrency/RP2040.h
@@ -4,7 +4,7 @@
 #include "AudioTools/Concurrency/SynchronizedQueue.h"
 #if defined(FREERTOS_H) || defined(INC_FREERTOS_H)
 #  include "RTOS.h" 
-#  define USE_FREETROS
+#  define USE_FREERTOS
 #else
 #  include "AudioTools/Concurrency/RP2040/BufferRP2040.h"
 #  include "AudioTools/Concurrency/RP2040/MutexRP2040.h"

--- a/src/AudioTools/Concurrency/STM32.h
+++ b/src/AudioTools/Concurrency/STM32.h
@@ -6,7 +6,7 @@
 #  if __has_include("STM32FreeRTOS.h")
 #    include "STM32FreeRTOS.h"
 #    include "RTOS.h"
-#    define USE_FREETROS
+#    define USE_FREERTOS
 #  else
 #    warning("STM32FreeRTOS not found")
 #  endif


### PR DESCRIPTION
Correct name for define that enables `USBAudioDeviceTinyUSBFreeRTOS`

note: seems like adafruit_nrf52 runs freertos under the hood, so enabling this stream usb audio finally starts working and producing sound (however for some reason conflicts with Serial/CDC if it activated, though it maybe a hardware/tinyusb issue, needed to test with raw tinyusb)