### PR TITLE
Fix out-of-bounds read in MTSDecoder::parsePMT()

### DIFF
--- a/src/AudioTools/AudioCodecs/CodecMTS.h
+++ b/src/AudioTools/AudioCodecs/CodecMTS.h
@@ -355,11 +355,16 @@ class MTSDecoder : public AudioDecoder {
     int staticLengthOfPMT = 12;
     int sectionLength = ((pmt[1] & 0x0F) << 8) | (pmt[2] & 0xFF);
     LOGI("- PMT Section Length: %d", sectionLength);
+    if (sectionLength >= len) {
+      LOGE("Unexpected PMT Section Length: %d", sectionLength);
+      sectionLength = len;
+    }
     int programInfoLength = ((pmt[10] & 0x0F) << 8) | (pmt[11] & 0xFF);
     LOGI("- PMT Program Info Length: %d", programInfoLength);
 
     int cursor = staticLengthOfPMT + programInfoLength;
     while (cursor < sectionLength - 1) {
+      if (cursor + 4 >= len) break;
       MTSStreamType streamType = static_cast<MTSStreamType>(pmt[cursor] & 0xFF);
       int elementaryPID =
           ((pmt[cursor + 1] & 0x1F) << 8) | (pmt[cursor + 2] & 0xFF);


### PR DESCRIPTION
## Problem

`MTSDecoder::parsePMT()` in `src/AudioTools/AudioCodecs/CodecMTS.h` reads the 12-bit `section_length` field directly from the PMT payload and uses it as the loop bound, without ever validating it against `len` (the actual number of bytes available in the packet/write buffer). This is inconsistent with `parsePAT()` in the same file, which already clamps `sectionLength` to `len`:

```cpp
if (sectionLength >= len) {
  LOGE("Unexpected PAT Section Length: %d", sectionLength);
  sectionLength = len;
}
```

Because `section_length` is attacker/stream-controlled (it can legally encode up to 4095 per the 12-bit field), a corrupted or crafted MPEG-TS PMT section causes the `while (cursor < sectionLength - 1)` loop to walk past the end of the `SingleBuffer`-backed write buffer (default `MTS_WRITE_BUFFER_SIZE` = 2000 bytes), reading out of bounds.

This is reachable from real usage: `MTSDecoder` is used by the `hls-buffer-i2s` and `streams-url_mts-hex` examples to parse MPEG-TS data pulled from an HTTP/HLS network stream, so malformed/truncated input from the network can trigger it.

## Reproduction

I reproduced this with a small guard-page harness (Windows `VirtualAlloc`/`VirtualProtect`, buffer placed directly against a `PAGE_NOACCESS` page) that transplants the unmodified `parsePMT()` loop logic. Feeding it a PMT section with `section_length = 0x0FFF (4095)` (a legal 12-bit value) and `program_info_length = 0` against a 2000-byte buffer reliably crashes the process (SIGSEGV) once the read cursor crosses the buffer boundary.

## Fix

Mirrors the existing `parsePAT()` pattern:
1. Clamp `sectionLength` to `len` right after it is parsed (same as `parsePAT()`).
2. As defense in depth, bounds-check each stream-entry read (`cursor + 4`) against `len` inside the loop before dereferencing, since `cursor` can also be pushed out of range by an oversized `esInfoLength` from a previous (in-bounds) entry.

With the fix, the same adversarial input safely breaks out of the loop instead of reading out of bounds, and normal two-entry PMT tables (verified with an AAC + AVC stream-type example) still parse correctly.

The diff is limited to this one function; no other logic (stream type / elementary PID / esInfoLength parsing, `addPID()`) is changed.