### PR TITLE
Replacing USB_INTERFACE_AUDIO with USB_INTERFACE_MIDI 

### DIFF
--- a/src/AudioTools/Communication/USB/USBAudioDeviceESP32.h
+++ b/src/AudioTools/Communication/USB/USBAudioDeviceESP32.h
@@ -101,7 +101,7 @@ class USBAudioDeviceESP32 : public USBAudioDeviceBase {
     static uint8_t desc[USB_DESCR_MAX_LEN];
     uint16_t audio_len = getDescriptor(desc);
     assert(audio_len <= USB_DESCR_MAX_LEN);
-    tinyusb_enable_interface(USB_INTERFACE_AUDIO, audio_len,
+    tinyusb_enable_interface(USB_INTERFACE_MIDI, audio_len,
                              descriptorCallback);
     return true;
   }

--- a/src/AudioTools/Communication/USB/USBAudioDeviceESP32.h
+++ b/src/AudioTools/Communication/USB/USBAudioDeviceESP32.h
@@ -29,7 +29,7 @@ class Emulated_TinyUSB;
  * the audio function descriptor block via the ESP32-specific API:
  *
  *  - `ESPUSB` (`USB.*`) — configures VID/PID/strings and starts the stack
- *  - `tinyusb_enable_interface(USB_INTERFACE_AUDIO, …)` — injects the UAC2
+ *  - `tinyusb_enable_interface(USB_INTERFACE_MIDI, …)` — injects the UAC2
  *    descriptor into the configuration descriptor the framework builds
  *
  * @note Timing: On ESP32, `USB.begin()` usually should be called explicitly. We provide a


### PR DESCRIPTION
USB_INTERFACE_AUDIO does not exist in the latest versions anymore