### PR TITLE
docs: fix typo unfortunatly -> unfortunately

### DIFF
--- a/examples/examples-stream/streams-i2s-serial/README.md
+++ b/examples/examples-stream/streams-i2s-serial/README.md
@@ -6,7 +6,7 @@
 We implement a I2S source: We stream the sound input which we read in from the I2S interface and displays it on the Arduino Serial Plotter. 
 
 We can use any device which provides the sound data via I2S. In this case it is a 'I2S ADC Audio I2S Capture Card Module'
-Usually you do not need any master clock, but unfortunatly we need to feed this module with a master clock signal from the ESP32, if
+Usually you do not need any master clock, but unfortunately we need to feed this module with a master clock signal from the ESP32, if
 the ESP32 is acting as master.
 
 ## Pins


### PR DESCRIPTION
Corrects the misspelling `unfortunatly` -> `unfortunately` in `examples/examples-stream/streams-i2s-serial/README.md`.

Documentation only, no behaviour change.