### PR TITLE
Add setRampTimes() to SoundGenerator for ramp up and down on arbitrary length sounds.

### DIFF
--- a/src/AudioTools/CoreAudio/AudioEffects/SoundGenerator.h
+++ b/src/AudioTools/CoreAudio/AudioEffects/SoundGenerator.h
@@ -6,6 +6,8 @@
 #include "AudioTools/CoreAudio/AudioLogger.h"
 #include "AudioTools/CoreAudio/AudioTypes.h"
 #include "AudioTools/CoreAudio/Buffers.h"
+#include "AudioTools/Concurrency/LockFree/RingBufferSPSC.h"
+
 
 /**
  * @defgroup generator Generators
@@ -1292,5 +1294,153 @@ class TestGenerator : public SoundGenerator<T> {
   T value = 0;
   T inc = 1;
 };
+
+/**
+ * @brief Queues SoundGenerators and plays them sequentially. Queued SoundGenerators
+ * must be limited (eg: setPlayTime()) or no later Generator will ever be played.
+ * @ingroup generator
+ * @author Mark Smith, @SmittyHalibut
+ * @copyright GPLv3
+ * @tparam T
+ */
+template <class T = int16_t>
+class GeneratorQueue : public SoundGenerator<T> {
+public:
+  bool begin(uint16_t queue_size=256) {
+    return queue.resize(queue_size) && SoundGenerator<T>::begin();
+  }
+
+  void end() { SoundGenerator<T>::end(); clear(); }
+
+  // Returns the requested number of bytes from the current generator.
+  // If the current generator runs out of bytes before the buffer is filled,
+  // it will move to the next queued generator.  If there are no more generators,
+  // it will stop filling the buffer and return the number of bytes it was able to fill.
+  virtual size_t readBytes(uint8_t *buffer, size_t buf_len) {
+    LOGD("readBytes: %d", (int)buf_len);
+    if (!SoundGenerator<T>::active) return 0;
+    if (queue.available() == 0) return 0;  // Nothing in the queue.
+
+    size_t bytes_read = 0;
+    size_t ret = 0;
+    SoundGenerator<T> *current_generator = nullptr;
+
+    while (bytes_read < buf_len) {
+      if ((current_generator = getCurrentGenerator()) == nullptr) break; // No generator.
+
+      ret = current_generator->readBytes(buffer+bytes_read, buf_len-bytes_read);
+      bytes_read += ret;
+
+      if (ret == 0) {
+        // Done with this generator, move to the next one.
+        removeCurrentGenerator();
+        if (queue.available() == 0) break;  // No more generators
+      }
+    }
+    return bytes_read;
+  }
+
+  // If no bytes are available, will return 0.
+  virtual T readSample() {
+    T buf;
+    if (readBytes((uint8_t *)&buf, sizeof(T)) != sizeof(T)) return (T)0;
+    return buf;
+  }
+
+  virtual inline size_t readSamples(T* data, size_t len) {
+    return (readBytes((uint8_t *)data, len*sizeof(T)) / sizeof(T));
+  }
+
+  // Add a generator to the queue.  The generator MUST be time limited BEFORE adding
+  // to the queue (eg: calling setPlayTime()). Otherwise, the generator will never
+  // run out of bytes and nothing after it will ever play.
+  virtual bool pushGenerator(SoundGenerator<T> *gen) {
+    LOGD("pushGenerator()");
+    if (queue.availableForWrite() == 0) return false;  // Queue is full.
+
+    QNode *node = new QNode;            // Deleted in removeCurrentGenerator;
+    if (node == nullptr) return false;  // new failed
+
+    node->restarted = false;
+    node->generator = gen;
+    if (!queue.write(node)) {
+      delete node;
+      return false;
+    }
+    return true;
+  }
+
+  // GeneratorQueue doesn't do everything other generators do.  We rely on the
+  // queued SoundGenerators to do any shaping.
+  virtual inline void setPlayTime(uint32_t p, uint8_t u = 20, uint8_t d = 30) {
+    LOGW("GeneratorQueue::setPlayTime() does nothing.");
+  }
+  virtual inline void setFrequency(float f) {
+    LOGW("GeneratorQueue::setFrequency() does nothing.");
+  }
+
+  virtual SoundGenerator<T> *peek() {
+    QNode *node;
+    if (!queue.peek(node)) return nullptr;
+    return node->generator;
+  }
+
+  virtual bool clear() {
+    while (removeCurrentGenerator()) {};  // Deletes all the QNodes.
+    return queue.available() == 0;
+  }
+
+  virtual inline size_t size()              { return queue.available(); }
+  virtual inline size_t available()         { return queue.available(); }
+  virtual inline size_t availableForWrite() { return queue.availableForWrite(); }
+  virtual inline bool empty()               { return queue.available() == 0; }
+
+protected:
+  struct QNode {
+    SoundGenerator<T> *generator;
+    bool restarted;
+  };
+
+  RingBufferSPSC<QNode *> queue;
+
+  // Returns the SoundGenerator at the head of the queue,
+  // restarting it if it hasn't been restarted yet.
+  SoundGenerator<T> *getCurrentGenerator() {
+    if (queue.available() == 0) return nullptr;
+
+    QNode *node = nullptr;
+    if (!queue.peek(node) || node == nullptr) return nullptr;
+
+    if (!node->restarted) {
+      node->generator->restart();
+      node->generator->begin();
+      node->restarted = true;      // persistent dynamic objects, this will persist.
+    }
+    return node->generator;
+  }
+
+  // Removes the current SoundGenerator from the queue, and cleans up memory use.
+  bool removeCurrentGenerator() {
+    if (queue.available() == 0) return false;
+
+    QNode *node = nullptr;
+    bool ret = queue.read(node);
+    if (node != nullptr) {
+      delete node;
+    }
+    return ret;
+  }
+
+  // readBytes(), readSample(), and readSamples() have all been reimplemented above
+  // and do not use readBytesFrames(), so this will never be called.  But it's not
+  // virtual in SoundGenerator so I can't overwrite it.
+  //size_t readBytesFrames(uint8_t *b, size_t l, int f, int c) {
+  //    LOGE("GeneratorQueue::readBytesFrames() should never get called.");
+  //    return 0;
+  //}
+
+};
+
+
 
 }  // namespace audio_tools

--- a/src/AudioTools/CoreAudio/AudioEffects/SoundGenerator.h
+++ b/src/AudioTools/CoreAudio/AudioEffects/SoundGenerator.h
@@ -133,10 +133,10 @@ class SoundGenerator {
     factor = 0.0f;
   }
 
-  /// Alternative to setPlayTime.  It sets ramp-up and ramp-down times in ms, 
+  /// Alternative to setPlayTime.  It sets ramp-up and ramp-down times in ms,
   /// without specifying a play time.   restart();begin(); starts the ramp-up and sustain
   /// as normal, but it will sustain forever. end(true) triggers a ramp-down then inactive.
-  virtual void setRampTimes(uint8_t upMs, uint8_t downMs) {
+  virtual void setRampTimes(uint32_t upMs, uint32_t downMs) {
     LOGI("setRampTimes: upMs=%d, downMs=%d", upMs, downMs);
 
     upSamples = info.sample_rate / 1000 * upMs;
@@ -150,7 +150,7 @@ class SoundGenerator {
     if (downSamples > 0) {
       rampDownDec = 1.0f / downSamples;
     }
-    LOGW("setRampTimes() playSamples: %u  playMs: %u  upSamples: %u  downSamples: %u", playSamples, playMs, upSamples, downSamples);
+    LOGD("setRampTimes() playSamples: %u  playMs: %u  upSamples: %u  downSamples: %u", playSamples, playMs, upSamples, downSamples);
   }
 
 

--- a/src/AudioTools/CoreAudio/AudioEffects/SoundGenerator.h
+++ b/src/AudioTools/CoreAudio/AudioEffects/SoundGenerator.h
@@ -136,29 +136,28 @@ class SoundGenerator {
     this->playMs = playMs;
     this->upPercent = upPercent;
     this->downPercent = downPercent;
+    this->upMs = 0;
+    this->downMs = 0;
     currentSample = 0;
     recalculatePlayTime();
     factor = 0.0f;
   }
 
-  /// Alternative to setPlayTime.  It sets ramp-up and ramp-down times in ms,
-  /// without specifying a play time.   restart();begin(); starts the ramp-up and sustain
+  /// Alternative to setPlayTime.  It sets ramp-up and ramp-down times in ms
+  /// instead of percentages.
+  /// If playMs == 0, it will play indefinitely. restart();begin(); starts the ramp-up and sustain
   /// as normal, but it will sustain forever. end(true) triggers a ramp-down then inactive.
-  virtual void setRampTimes(uint32_t upMs, uint32_t downMs) {
-    LOGI("setRampTimes: upMs=%d, downMs=%d", upMs, downMs);
+  virtual void setRampTimes(uint32_t playMs, uint32_t upMs = 5, uint32_t downMs = 5) {
+    LOGI("setRampTimes: playMs=%u  upMs=%u, downMs=%u", playMs, upMs, downMs);
+
+    this->playMs = playMs;
+    this->upMs = upMs;
+    this->downMs = downMs;
+    this->upPercent = 0;
+    this->downPercent = 0;
 
     currentSample = 0;
-    upSamples = info.sample_rate / 1000 * upMs;
-    downSamples = info.sample_rate / 1000 * downMs;
-    playSamples = 0;  // Play forever
-    rampUpInc = 0;
-    if (upSamples > 0) {
-      rampUpInc = 1.0f / upSamples;
-    }
-    rampDownDec = 0;
-    if (downSamples > 0) {
-      rampDownDec = 1.0f / downSamples;
-    }
+    recalculatePlayTime();
     factor = 0.0f;
     LOGD("setRampTimes() playSamples: %u  playMs: %u  upSamples: %u  downSamples: %u", playSamples, playMs, upSamples, downSamples);
   }
@@ -179,6 +178,8 @@ class SoundGenerator {
   uint32_t playMs = 0;
   uint8_t upPercent = 5;
   uint8_t downPercent = 40;
+  uint32_t upMs = 0;
+  uint32_t downMs = 0;
   uint32_t playSamples = 0;
   uint32_t upSamples = 0;
   uint32_t downSamples = 0;
@@ -188,12 +189,40 @@ class SoundGenerator {
   uint32_t currentSample = 0;
 
   void recalculatePlayTime() {
-    if (upPercent + downPercent > 100) {
-      downPercent = 100 - upPercent;
+    // Enforce exclusion between setPlayTime() and setRampTimes()
+    if ((upPercent || downPercent) && (upMs || downMs)) {
+      LOGE("Only use either: setPlayTime() or setRampTimes(), not both. up%% %u  down%% %u   upMs: %u  downMs: %u",
+        upPercent, downPercent, upMs, downMs);
+      LOGE("Reset the other to zero if switching back and forth.")
+      return;
     }
+
+    // Set playSamples. playMs == 0 results in playSamples == 0 will play
+    // indefinitely, until end() is called. end(true) will ramp-down,
+    // end(false) stops immediately.  Default is false/immediate.
     playSamples = info.sample_rate / 1000 * playMs;
-    upSamples = (playSamples * upPercent) / 100;
-    downSamples = (playSamples * downPercent) / 100;
+
+    // Set up/down samples based on either Percentages or times.
+    if (upMs || downMs) {
+      // Using ramp time in ms
+      upSamples = info.sample_rate / 1000 * upMs;
+      downSamples = info.sample_rate / 1000 * downMs;
+    }
+    else if (upPercent || downPercent) {
+      // Using ramp percentages of play time
+      if (upPercent + downPercent > 100) {
+        downPercent = 100 - upPercent;
+      }
+      upSamples = (playSamples * upPercent) / 100;
+      downSamples = (playSamples * downPercent) / 100;
+    }
+    else {
+      // No ramp specified.
+      upSamples = 0;
+      downSamples = 0;
+    }
+
+    // Turn all that into parameters to use in applyRamp()
     rampUpInc = 0;
     if (upSamples > 0) {
       rampUpInc = 1.0f / upSamples;

--- a/src/AudioTools/CoreAudio/AudioEffects/SoundGenerator.h
+++ b/src/AudioTools/CoreAudio/AudioEffects/SoundGenerator.h
@@ -1498,7 +1498,6 @@ protected:
         node->start_cb(node->generator, node->cb_data);
       }
       node->generator->restart();
-      node->generator->begin();
       node->restarted = true;      // persistent dynamic objects, this will persist.
     }
     return node->generator;

--- a/src/AudioTools/CoreAudio/AudioEffects/SoundGenerator.h
+++ b/src/AudioTools/CoreAudio/AudioEffects/SoundGenerator.h
@@ -1354,15 +1354,19 @@ public:
   // Add a generator to the queue.  The generator MUST be time limited BEFORE adding
   // to the queue (eg: calling setPlayTime()). Otherwise, the generator will never
   // run out of bytes and nothing after it will ever play.
-  virtual bool pushGenerator(SoundGenerator<T> *gen) {
+  // Callbacks are called in the context of read*() methods, so you probably want them
+  // to be quick and not block on anything.
+  virtual bool pushGenerator(SoundGenerator<T> *gen,
+    void (*start_cb)(SoundGenerator<T> *, const void *) = nullptr,
+    void (*end_cb)(SoundGenerator<T> *, const void *) = nullptr,
+    const void *cb_data = nullptr
+  ) {
     LOGD("pushGenerator()");
     if (queue.availableForWrite() == 0) return false;  // Queue is full.
 
-    QNode *node = new QNode;            // Deleted in removeCurrentGenerator;
+    QNode *node = new QNode(gen, start_cb, end_cb, cb_data); // Deleted in removeCurrentGenerator;
     if (node == nullptr) return false;  // new failed
 
-    node->restarted = false;
-    node->generator = gen;
     if (!queue.write(node)) {
       delete node;
       return false;
@@ -1398,7 +1402,12 @@ public:
 protected:
   struct QNode {
     SoundGenerator<T> *generator;
+    void (*start_cb)(SoundGenerator<T> *, const void *);
+    void (*end_cb)(SoundGenerator<T> *, const void *);
+    const void *cb_data;
     bool restarted;
+    QNode(SoundGenerator<T> *g, void (*s)(SoundGenerator<T> *, const void *), void (*e)(SoundGenerator<T> *, const void *), const void *d) :
+      generator(g), start_cb(s), end_cb(e), cb_data(d) { restarted=false; }
   };
 
   RingBufferSPSC<QNode *> queue;
@@ -1412,6 +1421,9 @@ protected:
     if (!queue.peek(node) || node == nullptr) return nullptr;
 
     if (!node->restarted) {
+      if (node->start_cb) {
+        node->start_cb(node->generator, node->cb_data);
+      }
       node->generator->restart();
       node->generator->begin();
       node->restarted = true;      // persistent dynamic objects, this will persist.
@@ -1426,6 +1438,9 @@ protected:
     QNode *node = nullptr;
     bool ret = queue.read(node);
     if (node != nullptr) {
+      if (node->end_cb) {
+        node->end_cb(node->generator, node->cb_data);
+      }
       delete node;
     }
     return ret;

--- a/src/AudioTools/CoreAudio/AudioEffects/SoundGenerator.h
+++ b/src/AudioTools/CoreAudio/AudioEffects/SoundGenerator.h
@@ -52,8 +52,18 @@ class SoundGenerator {
     return true;
   }
 
-  /// Ends the processing
-  virtual void end() { active = false; }
+  /// Ends the processing. If either setPlayTime() or setRampTimes() have been set, then
+  /// allow_rampdown=true will start a ramp-down instead of stopping immediately.
+  virtual void end(bool allow_rampdown=false) {
+    if (active && allow_rampdown && (downSamples > 0) && (currentSample < (playSamples-downSamples))) {
+      LOGD("end() starting rampdown: %ums", downSamples);
+      playSamples = currentSample + downSamples;
+    }
+    else {
+      LOGD("end() immediate");
+      active = false;
+    }
+  }
 
   /// Checks if the begin method has been called - after end() isActive is false
   virtual bool isActive() { return active; }
@@ -123,6 +133,27 @@ class SoundGenerator {
     factor = 0.0f;
   }
 
+  /// Alternative to setPlayTime.  It sets ramp-up and ramp-down times in ms, 
+  /// without specifying a play time.   restart();begin(); starts the ramp-up and sustain
+  /// as normal, but it will sustain forever. end(true) triggers a ramp-down then inactive.
+  virtual void setRampTimes(uint8_t upMs, uint8_t downMs) {
+    LOGI("setRampTimes: upMs=%d, downMs=%d", upMs, downMs);
+
+    upSamples = info.sample_rate / 1000 * upMs;
+    downSamples = info.sample_rate / 1000 * downMs;
+    playSamples = 0;  // Play forever
+    rampUpInc = 0;
+    if (upSamples > 0) {
+      rampUpInc = 1.0f / upSamples;
+    }
+    rampDownDec = 0;
+    if (downSamples > 0) {
+      rampDownDec = 1.0f / downSamples;
+    }
+    LOGW("setRampTimes() playSamples: %u  playMs: %u  upSamples: %u  downSamples: %u", playSamples, playMs, upSamples, downSamples);
+  }
+
+
   /// Restarts the generator, e.g. after a play time has been defined and reached
   virtual void restart() {
     currentSample = 0;
@@ -139,7 +170,7 @@ class SoundGenerator {
   uint8_t downPercent = 40;
   uint32_t playSamples = 0;
   uint32_t upSamples = 0;
-  uint32_t rampDownSamples = 0;
+  uint32_t downSamples = 0;
   float rampUpInc = 0.0;
   float rampDownDec = 0.0;
   float factor = 1.0f;
@@ -151,14 +182,14 @@ class SoundGenerator {
     }
     playSamples = info.sample_rate / 1000 * playMs;
     upSamples = (playSamples * upPercent) / 100;
-    rampDownSamples = (playSamples * downPercent) / 100;
+    downSamples = (playSamples * downPercent) / 100;
     rampUpInc = 0;
     if (upSamples > 0) {
       rampUpInc = 1.0f / upSamples;
     }
     rampDownDec = 0;
-    if (rampDownSamples > 0) {
-      rampDownDec = 1.0f / rampDownSamples;
+    if (downSamples > 0) {
+      rampDownDec = 1.0f / downSamples;
     }
   }
 
@@ -166,15 +197,16 @@ class SoundGenerator {
                          int channels) {
     T* result_buffer = (T*)buffer;
     int frames_written = 0;
-    if (playMs > 0 && currentSample > playSamples) {
+    if (playSamples > 0 && currentSample > playSamples) {
+      active = false;
       return 0;
     }
 
     for (int j = 0; j < frames; j++) {
       T sample = readSample();
 
-      // if we requested a play time
-      if (playMs > 0) {
+      // if we requested a play time or ramp times
+      if (playSamples > 0 || upSamples > 0 || downSamples > 0) {
         currentSample++;
         sample = applyRamp(sample);
       }
@@ -185,7 +217,8 @@ class SoundGenerator {
 
       frames_written++;
       // exit loop if we have reached the requested play time
-      if (playMs > 0 && currentSample > playSamples) {
+      if (playSamples > 0 && currentSample > playSamples) {
+        active = false;
         break;
       }
     }
@@ -202,7 +235,7 @@ class SoundGenerator {
       }
     }
     // Ramp down
-    else if (rampDownDec > 0 && currentSample >= playSamples - rampDownSamples) {
+    else if (rampDownDec > 0 && currentSample >= playSamples - downSamples) {
       factor -= rampDownDec;
       if (factor < 0.0f) {
         factor = 0.0f;

--- a/src/AudioTools/CoreAudio/AudioEffects/SoundGenerator.h
+++ b/src/AudioTools/CoreAudio/AudioEffects/SoundGenerator.h
@@ -52,16 +52,24 @@ class SoundGenerator {
     return true;
   }
 
+  virtual void end() { end(false); }
+
   /// Ends the processing. If either setPlayTime() or setRampTimes() have been set, then
   /// allow_rampdown=true will start a ramp-down instead of stopping immediately.
-  virtual void end(bool allow_rampdown=false) {
-    if (active && allow_rampdown && (downSamples > 0) && (currentSample < (playSamples-downSamples))) {
-      LOGD("end() starting rampdown: %ums", downSamples);
-      playSamples = currentSample + downSamples;
-    }
-    else {
+  virtual void end(bool allow_rampdown) {
+    if (!active || !allow_rampdown || downSamples == 0) {
+      // No rampdown to do
       LOGD("end() immediate");
       active = false;
+    }
+    // Are we already in a rampdown?  If so, don't restart it.
+    else if (currentSample > playSamples && currentSample <= playSamples + downSamples) {
+      LOGD("end() continuing rampdown: %u more samples", playSamples+downSamples-currentSample);  
+    }
+    // Otherwise, trigger the start of ramp down.
+    else {
+      LOGD("end() starting rampdown: %u samples", downSamples);
+      playSamples = currentSample + downSamples;
     }
   }
 
@@ -139,6 +147,7 @@ class SoundGenerator {
   virtual void setRampTimes(uint32_t upMs, uint32_t downMs) {
     LOGI("setRampTimes: upMs=%d, downMs=%d", upMs, downMs);
 
+    currentSample = 0;
     upSamples = info.sample_rate / 1000 * upMs;
     downSamples = info.sample_rate / 1000 * downMs;
     playSamples = 0;  // Play forever
@@ -150,6 +159,7 @@ class SoundGenerator {
     if (downSamples > 0) {
       rampDownDec = 1.0f / downSamples;
     }
+    factor = 0.0f;
     LOGD("setRampTimes() playSamples: %u  playMs: %u  upSamples: %u  downSamples: %u", playSamples, playMs, upSamples, downSamples);
   }
 
@@ -157,6 +167,7 @@ class SoundGenerator {
   /// Restarts the generator, e.g. after a play time has been defined and reached
   virtual void restart() {
     currentSample = 0;
+    active = true;
   }
 
  protected:
@@ -1339,17 +1350,17 @@ class TestGenerator : public SoundGenerator<T> {
 template <class T = int16_t>
 class GeneratorQueue : public SoundGenerator<T> {
 public:
-  bool begin(uint16_t queue_size=256) {
+  virtual bool begin(uint16_t queue_size=256) {
     return queue.resize(queue_size) && SoundGenerator<T>::begin();
   }
 
-  void end() { SoundGenerator<T>::end(); clear(); }
+  virtual void end() override { SoundGenerator<T>::end(); clear(); }
 
   // Returns the requested number of bytes from the current generator.
   // If the current generator runs out of bytes before the buffer is filled,
   // it will move to the next queued generator.  If there are no more generators,
   // it will stop filling the buffer and return the number of bytes it was able to fill.
-  virtual size_t readBytes(uint8_t *buffer, size_t buf_len) {
+  virtual size_t readBytes(uint8_t *buffer, size_t buf_len) override {
     LOGD("readBytes: %d", (int)buf_len);
     if (!SoundGenerator<T>::active) return 0;
     if (queue.available() == 0) return 0;  // Nothing in the queue.
@@ -1374,13 +1385,13 @@ public:
   }
 
   // If no bytes are available, will return 0.
-  virtual T readSample() {
+  virtual T readSample() override {
     T buf;
     if (readBytes((uint8_t *)&buf, sizeof(T)) != sizeof(T)) return (T)0;
     return buf;
   }
 
-  virtual inline size_t readSamples(T* data, size_t len) {
+  virtual inline size_t readSamples(T* data, size_t len) override {
     return (readBytes((uint8_t *)data, len*sizeof(T)) / sizeof(T));
   }
 
@@ -1409,10 +1420,10 @@ public:
 
   // GeneratorQueue doesn't do everything other generators do.  We rely on the
   // queued SoundGenerators to do any shaping.
-  virtual inline void setPlayTime(uint32_t p, uint8_t u = 20, uint8_t d = 30) {
+  virtual inline void setPlayTime(uint32_t p, uint8_t u = 20, uint8_t d = 30) override {
     LOGW("GeneratorQueue::setPlayTime() does nothing.");
   }
-  virtual inline void setFrequency(float f) {
+  virtual inline void setFrequency(float f) override {
     LOGW("GeneratorQueue::setFrequency() does nothing.");
   }
 
@@ -1430,7 +1441,7 @@ public:
   virtual inline size_t size()              { return queue.available(); }
   virtual inline size_t available()         { return queue.available(); }
   virtual inline size_t availableForWrite() { return queue.availableForWrite(); }
-  virtual inline bool empty()               { return queue.available() == 0; }
+  virtual inline bool   empty()             { return queue.available() == 0; }
 
 protected:
   struct QNode {

--- a/src/AudioTools/CoreAudio/RTTTLOutput.h
+++ b/src/AudioTools/CoreAudio/RTTTLOutput.h
@@ -253,6 +253,7 @@ class RTTTLOutput : public AudioOutput {
 
     p_generator->setPlayTime(msec, m_ramp_upPercent, m_ramp_downPercent);
     p_generator->setFrequency(freq);
+    p_generator->restart();
     uint8_t buffer[1024];
     size_t len = p_generator->readBytes(buffer, 1024);
     while (len > 0) {


### PR DESCRIPTION
Adds `setRampTimes()` to SoundGenerator, allowing ramp up and down on arbitrary length tones.  `restart(); begin();` will trigger a ramp-up, exactly as if `setPlayTime()` were called.  ~~But it will continue to play forever.~~  The user can specify `playMs = 0` to have the tone play forever.  To ramp-down and stop the tone, call `end(true)`.

`end()` defaults to the same behavior as before, immediate termination of the tone.

Renamed `rampDownSamples` to `downSamples` to match the rest of the similar variables.